### PR TITLE
Docs/bayes posttest clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
+## What this project does
+
+This project is a **Bayesian post-test probability calculator** for diagnostic tests.  
+It demonstrates how Bayes’ theorem updates the probability of disease once you know a test result.
+
+It is **not** a lifetime disease risk predictor or a survival model.  
+Instead, it focuses on a fundamental clinical reasoning process:
+
+> “How much more (or less) likely is this disease after seeing the test result?”
+
+
+## How it works
+
+Given:
+- **Prior probability** – baseline chance of having the disease (e.g., prevalence or pre-test clinical suspicion)
+- **Test sensitivity** – P(test positive | disease present)
+- **Test specificity** – P(test negative | disease absent)
+- **Observed test result** – either “positive” or “negative”
+
+The calculator applies **Bayes’ theorem** to compute the **posterior probability**:
+the updated probability that the patient has the disease *given the test result*.
+
+
+## Clinical example
+
+Suppose:
+- Disease prevalence = 10% (prior probability = 0.10)
+- Test sensitivity = 90%
+- Test specificity = 95%
+
+**Case 1: Positive test result**  
+\[
+P(\text{disease | positive}) = \frac{0.9 \times 0.10}{(0.9 \times 0.10) + (0.05 \times 0.90)} \approx 67\%
+\]
+
+**Case 2: Negative test result**  
+\[
+P(\text{disease | negative}) = \frac{0.10 \times (1 - 0.90)}{(0.10 \times 0.10) + (0.95 \times 0.90)} \approx 1.1\%
+\]
+
+So the test increases disease probability from **10% to ~67%** when positive,  
+and decreases it to **~1%** when negative.
+
+## Why this matters
+
+Diagnostic tests don’t provide certainty — they **shift probabilities**.  
+This tool makes that reasoning explicit and transparent.
+
+It can be useful as:
+- An **educational resource** for medical students and data scientists learning Bayes’ theorem
+- A **demo app** for understanding how diagnostic tests affect decision-making
+- A foundation to expand toward multi-feature or longitudinal models later
+
+
 # Disease-prediction
 A probability calculator using Baye's Theorem to estimate survival chances of a disease based on past hospital data.
 

--- a/templates/tests/test_validation.py
+++ b/templates/tests/test_validation.py
@@ -1,0 +1,40 @@
+import pytest
+from app import bayes_theorem, survival_chance
+
+def test_valid_bounds_positive():
+    assert 0 <= bayes_theorem(0.1, 0.9, 0.95, "positive") <= 1
+
+def test_valid_bounds_negative():
+    assert 0 <= bayes_theorem(0.1, 0.9, 0.95, "negative") <= 1
+
+@pytest.mark.parametrize("prior", [-0.1, 1.1])
+def test_prior_out_of_bounds(prior):
+    with pytest.raises(ValueError):
+        bayes_theorem(prior, 0.9, 0.95, "positive")
+
+@pytest.mark.parametrize("sens", [-0.01, 1.01])
+def test_sensitivity_out_of_bounds(sens):
+    with pytest.raises(ValueError):
+        bayes_theorem(0.1, sens, 0.95, "positive")
+
+@pytest.mark.parametrize("spec", [-0.2, 1.2])
+def test_specificity_out_of_bounds(spec):
+    with pytest.raises(ValueError):
+        bayes_theorem(0.1, 0.9, spec, "positive")
+
+def test_invalid_test_result():
+    with pytest.raises(ValueError):
+        bayes_theorem(0.1, 0.9, 0.95, "posi-tive")  # typo
+
+def test_division_by_zero_guard():
+    # Construct a degenerate case where denominator would be zero
+    # For negative branch: numerator=(1-sens)*prior, denominator=numerator + spec*(1-prior)
+    # If prior=0 and spec=1 and test_result='negative' -> denom = 0 + 1*(1-0)=1 (safe)
+    # For positive branch: prior=0, spec=1 -> denom=(1-1)*(1-0)=0 (since numerator=0 as well) -> 0
+    with pytest.raises(ValueError):
+        bayes_theorem(0.0, 0.9, 1.0, "positive")
+
+def test_alias_matches_main():
+    v1 = bayes_theorem(0.1, 0.9, 0.95, "positive")
+    v2 = survival_chance(0.1, 0.9, 0.95, "positive")
+    assert v1 == v2

--- a/templates/updated_index.html
+++ b/templates/updated_index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Disease Prediction (Bayes)</title>
+  <style>
+    .error { background: #ffe8e8; color: #900; padding: 10px; border-radius: 6px; margin-bottom: 12px; }
+    .result { background: #eef8ff; color: #034; padding: 10px; border-radius: 6px; margin-top: 12px; }
+    label { display:block; margin: 8px 0 4px; }
+    input, select { width: 100%; padding: 6px; }
+    .container { max-width: 520px; margin: 32px auto; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+    button { margin-top: 12px; padding: 8px 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Bayesian Post-Test Probability Calculator</h1>
+
+    {% if error %}
+      <div class="error">{{ error }}</div>
+    {% endif %}
+
+    <form method="post">
+      <label for="prior_probability">Prior probability (0–1)</label>
+      <input type="number" step="any" min="0" max="1" name="prior_probability" id="prior_probability"
+             value="{{ values.prior_probability }}"/>
+
+      <label for="test_sensitivity">Sensitivity (0–1)</label>
+      <input type="number" step="any" min="0" max="1" name="test_sensitivity" id="test_sensitivity"
+             value="{{ values.test_sensitivity }}"/>
+
+      <label for="test_specificity">Specificity (0–1)</label>
+      <input type="number" step="any" min="0" max="1" name="test_specificity" id="test_specificity"
+             value="{{ values.test_specificity }}"/>
+
+      <label for="test_result">Test result</label>
+      <select name="test_result" id="test_result">
+        <option value="positive" {% if values.test_result == "positive" %}selected{% endif %}>Positive</option>
+        <option value="negative" {% if values.test_result == "negative" %}selected{% endif %}>Negative</option>
+      </select>
+
+      <button type="submit">Calculate</button>
+    </form>
+
+    {% if result is not none %}
+      <div class="result">
+        <strong>Posterior probability:</strong> {{ '{:.4f}'.format(result) }} ({{ '{:.2%}'.format(result) }})
+      </div>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/updated_app.py
+++ b/updated_app.py
@@ -1,0 +1,89 @@
+from flask import Flask, render_template, request
+app = Flask(__name__)
+
+def _assert_prob(name: str, value: float):
+    if not (0.0 <= value <= 1.0):
+        raise ValueError(f"{name} must be between 0 and 1 (inclusive). Got {value}.")
+
+def bayes_theorem(prior_probability, test_sensitivity, test_specificity, test_result):
+    """
+    Calculate the posterior probability of disease given a test result,
+    using Bayes' theorem, with input validation.
+
+    Args:
+        prior_probability (float): baseline probability of disease (0–1)
+        test_sensitivity (float): P(test+ | disease) (0–1)
+        test_specificity (float): P(test- | no disease) (0–1)
+        test_result (str): "positive" or "negative"
+
+    Returns:
+        float: posterior probability of disease given the test result
+    """
+    _assert_prob("prior_probability", prior_probability)
+    _assert_prob("test_sensitivity", test_sensitivity)
+    _assert_prob("test_specificity", test_specificity)
+
+    if test_result not in {"positive", "negative"}:
+        raise ValueError('test_result must be either "positive" or "negative".')
+
+    if test_result == "positive":
+        numerator = test_sensitivity * prior_probability
+        denominator = numerator + (1 - test_specificity) * (1 - prior_probability)
+    else:  # negative
+        numerator = (1 - test_sensitivity) * prior_probability
+        denominator = numerator + test_specificity * (1 - prior_probability)
+
+    if denominator == 0:
+        raise ValueError(
+            "Inputs lead to an undefined calculation (division by zero). "
+            "Try avoiding degenerate combinations (e.g., prior=0 with specificity=1 on a negative path, or similar)."
+        )
+
+    posterior_probability = numerator / denominator
+    return posterior_probability
+
+
+# Backwards-compatible alias
+def survival_chance(prior, sensitivity, specificity, test_result):
+    """Deprecated alias for bayes_theorem (kept for backwards compatibility)."""
+    return bayes_theorem(prior, sensitivity, specificity, test_result)
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    error = None
+    result = None
+    # Pre-fill reasonable defaults for a quick demo
+    defaults = {
+        "prior_probability": "0.10",
+        "test_sensitivity": "0.90",
+        "test_specificity": "0.95",
+        "test_result": "positive",
+    }
+
+    form_values = dict(defaults)
+
+    if request.method == "POST":
+        form_values["prior_probability"] = request.form.get("prior_probability", "").strip()
+        form_values["test_sensitivity"] = request.form.get("test_sensitivity", "").strip()
+        form_values["test_specificity"] = request.form.get("test_specificity", "").strip()
+        form_values["test_result"] = request.form.get("test_result", "").strip().lower()
+
+        try:
+            prior = float(form_values["prior_probability"])
+            sens = float(form_values["test_sensitivity"])
+            spec = float(form_values["test_specificity"])
+            test_res = form_values["test_result"]
+
+            result = bayes_theorem(prior, sens, spec, test_res)
+
+        except ValueError as e:
+            error = str(e)
+        except Exception:
+            error = "Unexpected error: please check your inputs."
+
+    return render_template("index.html", result=result, error=error, values=form_values)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
fix: enforce 0–1 validation for prior/sensitivity/specificity + UI error display + tests