### PR TITLE
Deploy Disease-prediction Flask App to Render (#44)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn run:app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn run:app
+gunicorn run:app

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -9,6 +9,9 @@
 
 <body>
   <div class="container">
+    <div class="error" style="background:#fff3cd;color:#856404;border:1px solid #ffeeba;margin-bottom:18px;">
+      <strong>Disclaimer:</strong> This is just a test implementation and must not be used for real medical analysis or decision making.
+    </div>
     <h1>Probability Calculator with Disease Detection</h1>
 
     <section>

--- a/backend/templates/updated_index.html
+++ b/backend/templates/updated_index.html
@@ -14,6 +14,9 @@
 </head>
 <body>
   <div class="container">
+    <div class="error" style="background:#fff3cd;color:#856404;border:1px solid #ffeeba;margin-bottom:18px;">
+      <strong>Disclaimer:</strong> This is just a test implementation and must not be used for real medical analysis or decision making.
+    </div>
     <h1>Bayesian Post-Test Probability Calculator</h1>
 
     {% if error %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 pytest
 pytest-flask
+gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 flask
 pytest
 pytest-flask
-os


### PR DESCRIPTION
This PR resolves #44  by deploying the Disease-prediction Flask application to [Render.com](https://render.com/)
 as a public web service.

✅ Changes Made:

Added Procfile for Render deployment with Gunicorn

Updated requirements.txt to include Gunicorn and removed unused built-in modules

Configured start command for production (gunicorn backend:app)

Added deployment disclaimer on the homepage stating it’s for educational/demo use only

Verified successful deployment at: https://disease-prediction-gcqf.onrender.com/