### PR TITLE
Fix glitches in custom data input on calculator page

### DIFF
--- a/backend/static/script.js
+++ b/backend/static/script.js
@@ -533,14 +533,20 @@ function initInteractiveSliders() {
       resetResultDisplay();
     });
 
+    // Allow partial typing states
     pDInput.addEventListener('input', function () {
-      let value = parseFloat(this.value) || 0;
-      value = Math.max(0, Math.min(1, value)); // Clamp to [0, 1]
-      this.value = value;
-      pDSlider.value = value;
-      updateSliderValue('pDValue', value);
-      resetResultDisplay();
-    });
+      const raw = this.value;
+      if (raw === '' || raw === '.' || raw === '0.') return;
+
+      const value = Number(raw);
+      if (isNaN(value)) return;
+
+      if (value >= 0 && value <= 1) {
+        pDSlider.value = value;
+        updateSliderValue('pDValue', value);
+      }
+    }); 
+
   }
 
   // Sync sliders with number inputs for Sensitivity
@@ -551,13 +557,18 @@ function initInteractiveSliders() {
       resetResultDisplay();
     });
 
+    // Allow partial typing states
     sensitivityInput.addEventListener('input', function () {
-      let value = parseFloat(this.value) || 0;
-      value = Math.max(0, Math.min(1, value));
-      this.value = value;
-      sensitivitySlider.value = value;
-      updateSliderValue('sensitivityValue', value);
-      resetResultDisplay();
+      const raw = this.value;
+      if (raw === '' || raw === '.' || raw === '0.') return;
+
+      const value = Number(raw);
+      if (isNaN(value)) return;
+
+      if (value >= 0 && value <= 1) {
+        sensitivitySlider.value = value;
+        updateSliderValue('sensitivityValue', value);
+      }
     });
   }
 
@@ -569,13 +580,18 @@ function initInteractiveSliders() {
       resetResultDisplay();
     });
 
+    // Allow partial typing states
     falsePositiveInput.addEventListener('input', function () {
-      let value = parseFloat(this.value) || 0;
-      value = Math.max(0, Math.min(1, value));
-      this.value = value;
-      falsePositiveSlider.value = value;
-      updateSliderValue('falsePositiveValue', value);
-      resetResultDisplay();
+      const raw = this.value;
+      if (raw === '' || raw === '.' || raw === '0.') return;
+
+      const value = Number(raw);
+      if (isNaN(value)) return;
+
+      if (value >= 0 && value <= 1) {
+        falsePositiveSlider.value = value;
+        updateSliderValue('falsePositiveValue', value);
+      }
     });
   }
 


### PR DESCRIPTION
## 📄 Description

This PR fixes UI glitches on the **Calculator → Enter Custom Data** section that occurred while manually entering probability values.

Previously, inputs were forcefully overwritten during typing, sliders conflicted with manual input, and results flickered.  
This update improves UX stability and ensures calculations only happen on explicit user action.

## 🔗 Related Issues

Fixes #101

## ✨ Changes Summary

- Fixed glitches while manually entering custom probability values
- Allowed partial numeric inputs (e.g. `0.`, `0.05`) without forced overwrites
- Prevented slider–input feedback loops
- Stopped result/chart flickering during typing
- Ensured calculation runs only when **“Check Result”** is clicked

## 📸 Screenshots (if applicable)

_Not applicable (behavioral UX improvement with no layout changes)._

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings