### PR TITLE
Add scrollable pre-loaded dataset section under Calculator page #93

### DIFF
--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -890,3 +890,38 @@ body.dark-mode .form-range::-webkit-slider-thumb {
 body.dark-mode .form-range::-moz-range-thumb {
     background: linear-gradient(135deg, #1abc9c, #16a085);
 }
+
+.preloaded-info {
+  margin-top: 20px;
+}
+
+.preloaded-info h4 {
+  font-size: 14px;
+  margin-bottom: 6px;
+  color: #333;
+}
+
+.preloaded-scroll {
+  max-height: 180px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 10px;
+  background-color: #f9f9f9;
+}
+
+.preloaded-scroll ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.preloaded-scroll li {
+  padding: 6px 0;
+  border-bottom: 1px solid #e5e5e5;
+  font-size: 13px;
+}
+
+.preloaded-scroll li:last-child {
+  border-bottom: none;
+}

--- a/backend/templates/calculator.html
+++ b/backend/templates/calculator.html
@@ -73,6 +73,22 @@
                         id="loadSampleBtn">
                         <i class="fas fa-file-import me-2"></i>Load Sample Data
                     </button>
+                    <!-- Pre-loaded Dataset Info -->
+                    <div class="preloaded-info">
+                    <h4>Available Sample Data</h4>
+
+                    <div class="preloaded-scroll">
+                        <ul>
+                        <li>Migraine – Prior: 0.01</li>
+                        <li>Influenza – Prior: 0.03</li>
+                        <li>Diabetes – Prior: 0.12</li>
+                        <li>Hypertension – Prior: 0.18</li>
+                        <li>Heart Disease – Prior: 0.07</li>
+                        <li>Asthma – Prior: 0.05</li>
+                        </ul>
+                    </div>
+                    </div>
+
                     <small class="text-muted mt-3">Adjust details below, then click Check</small>
                 </div>
             </div>


### PR DESCRIPTION
**Description**

This PR adds a fixed-height, scrollable pre-loaded dataset section under the Calculator page to better utilize empty space and improve visual structure.

**Related Issue**
Fixes #93

**Changes**
- Added a scrollable dataset information section
- Improved UI layout on Calculator page
- No backend logic affected

**Screenshots**
<img width="1919" height="1020" alt="image" src="https://github.com/user-attachments/assets/df8ecb12-daae-48c8-b0ab-1fff1d03f03a" />

