### PR TITLE
Fix dark mode styling for Prediction Results card on Home page 

### DIFF
--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -925,3 +925,46 @@ body.dark-mode .form-range::-moz-range-thumb {
 .preloaded-scroll li:last-child {
   border-bottom: none;
 }
+
+/* Dark Mode – Home Prediction Results */
+
+body.dark-mode .prediction-results-card {
+    background-color: #1e1e1e;
+    color: #eaeaea;
+    border: 1px solid #2a2a2a;
+}
+
+/* Headings */
+body.dark-mode .prediction-results-card h2,
+body.dark-mode .prediction-results-card h3,
+body.dark-mode .prediction-results-card h4,
+body.dark-mode .prediction-results-card h6 {
+    color: #ffffff;
+}
+
+/* Inner cards (ML, Bayesian, Risk, Download) */
+body.dark-mode .prediction-results-card .card {
+    background-color: #252525 !important;
+    border-color: #333;
+    color: #eaeaea;
+}
+
+/* Remove Bootstrap bg-light effect */
+body.dark-mode .prediction-results-card .bg-light {
+    background-color: #3a3a3a !important;
+}
+
+/* Muted text */
+body.dark-mode .prediction-results-card .text-muted {
+    color: #b0b0b0 !important;
+}
+
+/* Progress bars */
+body.dark-mode .prediction-results-card .progress {
+    background-color: #333;
+}
+
+/* Download card border */
+body.dark-mode .prediction-results-card .border-primary {
+    border-color: #0d6efd;
+}

--- a/backend/templates/home.html
+++ b/backend/templates/home.html
@@ -57,7 +57,7 @@
 
     <!-- Results Panel -->
     <div class="col-lg-6">
-        <div class="card h-100 shadow-sm">
+        <div class="card h-100 shadow-sm prediction-results-card">
             <div class="card-body p-4">
                 <h2 class="h4 mb-4">
                     <i class="fas fa-chart-line me-2"></i>Prediction Results


### PR DESCRIPTION
**Issue Fix: Dark mode UI inconsistency on Home page**
This PR fixes the bright/light background appearing in the **Prediction Results** section when dark mode is enabled on the Home page.

**What was done**
- Applied dark-mode-friendly background colors to the Prediction Results card
- Updated inner cards, text, and progress bars for better contrast
- Ensured consistency with the rest of the dark-themed UI
- Light mode behavior remains unchanged

**Fixes #110**

**Screenshots**
Before
<img width="1919" height="1017" alt="image" src="https://github.com/user-attachments/assets/37efbf62-4c3b-4a59-98ef-6d0425256738" />

After
<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/56e5cc75-01a3-432e-a58b-c9d46540376a" />

**Contribution**
Completed as part of **Social Winter of Code (SWoC) Season 6**
