### PR TITLE
Add temporal disease progression analysis

### DIFF
--- a/backend/analysis/temporal_progression.py
+++ b/backend/analysis/temporal_progression.py
@@ -1,0 +1,229 @@
+"""
+Temporal progression analysis for sequential patient prediction history.
+
+The current disease model scores a single visit. This module layers a small,
+deterministic time-series analysis over saved PredictionHistory records so the
+application can describe how a patient's risk changes across visits.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+
+RISK_SEVERITY = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+
+def _prediction_probability(prediction: Any) -> float:
+    probability = prediction.bayesian_posterior
+    if probability is None:
+        probability = prediction.ml_probability
+    return float(probability or 0.0)
+
+
+def _clamp_probability(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _linear_slope(values: List[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+
+    n = len(values)
+    mean_x = (n - 1) / 2
+    mean_y = sum(values) / n
+    numerator = sum((idx - mean_x) * (value - mean_y) for idx, value in enumerate(values))
+    denominator = sum((idx - mean_x) ** 2 for idx in range(n))
+    return numerator / denominator if denominator else 0.0
+
+
+def _trend_direction(slope: float, delta: float) -> str:
+    if slope >= 0.02 or delta >= 0.05:
+        return "worsening"
+    if slope <= -0.02 or delta <= -0.05:
+        return "improving"
+    return "stable"
+
+
+def _weighted_recent_probability(probabilities: List[float], half_life: float = 2.0) -> float:
+    if not probabilities:
+        return 0.0
+
+    weighted_sum = 0.0
+    total_weight = 0.0
+    last_index = len(probabilities) - 1
+
+    for index, probability in enumerate(probabilities):
+        age = last_index - index
+        weight = 0.5 ** (age / half_life)
+        weighted_sum += probability * weight
+        total_weight += weight
+
+    return weighted_sum / total_weight if total_weight else 0.0
+
+
+def _risk_transition(previous: Optional[str], current: str) -> str:
+    if previous is None:
+        return "baseline"
+
+    previous_score = RISK_SEVERITY.get(previous, 0)
+    current_score = RISK_SEVERITY.get(current, 0)
+
+    if current_score > previous_score:
+        return "escalated"
+    if current_score < previous_score:
+        return "deescalated"
+    return "unchanged"
+
+
+def analyze_temporal_progression(
+    predictions: Iterable[Any],
+    disease: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Analyze sequential PredictionHistory records.
+
+    Args:
+        predictions: PredictionHistory-like objects.
+        disease: Optional disease key used by the caller for filtered histories.
+
+    Returns:
+        Dict containing timeline points, trend metrics, weighted recent risk,
+        symptom progression, and dynamic probability updates.
+    """
+    ordered = sorted(
+        predictions,
+        key=lambda item: item.created_at or datetime.min,
+    )
+
+    if not ordered:
+        return {
+            "disease": disease,
+            "observation_count": 0,
+            "trend": {
+                "direction": "insufficient_data",
+                "slope_per_observation": 0.0,
+                "probability_delta": 0.0,
+                "volatility": 0.0,
+            },
+            "recent_weighted_probability": 0.0,
+            "latest_probability": 0.0,
+            "timeline": [],
+            "symptom_progression": {
+                "new_symptoms": [],
+                "resolved_symptoms": [],
+                "persistent_symptoms": [],
+                "most_frequent_symptoms": [],
+            },
+            "dynamic_updates": [],
+            "interpretation": "Not enough sequential history to assess progression.",
+        }
+
+    probabilities = [_prediction_probability(prediction) for prediction in ordered]
+    first_probability = probabilities[0]
+    latest_probability = probabilities[-1]
+    probability_delta = latest_probability - first_probability
+    slope = _linear_slope(probabilities)
+    direction = _trend_direction(slope, probability_delta)
+
+    deltas = [
+        abs(probabilities[index] - probabilities[index - 1])
+        for index in range(1, len(probabilities))
+    ]
+    volatility = sum(deltas) / len(deltas) if deltas else 0.0
+    recent_weighted = _weighted_recent_probability(probabilities)
+
+    all_symptoms = [set(prediction.get_symptoms_list()) for prediction in ordered]
+    first_symptoms = all_symptoms[0]
+    latest_symptoms = all_symptoms[-1]
+    symptom_counts = Counter(
+        symptom
+        for symptom_set in all_symptoms
+        for symptom in symptom_set
+    )
+
+    timeline = []
+    dynamic_updates = []
+    previous_probability = None
+    previous_risk = None
+    running_probabilities: List[float] = []
+
+    for index, prediction in enumerate(ordered):
+        probability = probabilities[index]
+        running_probabilities.append(probability)
+        delta_from_previous = (
+            0.0 if previous_probability is None else probability - previous_probability
+        )
+        risk_transition = _risk_transition(previous_risk, prediction.risk_level)
+        symptoms = sorted(all_symptoms[index])
+
+        point = {
+            "id": prediction.id,
+            "disease": prediction.disease,
+            "created_at": prediction.created_at.isoformat() if prediction.created_at else None,
+            "probability": round(probability, 4),
+            "probability_percent": round(probability * 100, 2),
+            "delta_from_previous": round(delta_from_previous, 4),
+            "risk_level": prediction.risk_level,
+            "risk_transition": risk_transition,
+            "symptoms": symptoms,
+            "symptom_count": len(symptoms),
+        }
+        timeline.append(point)
+
+        dynamic_updates.append({
+            "created_at": point["created_at"],
+            "updated_probability": round(_weighted_recent_probability(running_probabilities), 4),
+            "visit_probability": point["probability"],
+            "delta_from_previous": point["delta_from_previous"],
+            "risk_transition": risk_transition,
+        })
+
+        previous_probability = probability
+        previous_risk = prediction.risk_level
+
+    symptom_progression = {
+        "new_symptoms": sorted(latest_symptoms - first_symptoms),
+        "resolved_symptoms": sorted(first_symptoms - latest_symptoms),
+        "persistent_symptoms": sorted(first_symptoms & latest_symptoms),
+        "most_frequent_symptoms": [
+            {"symptom": symptom, "count": count}
+            for symptom, count in symptom_counts.most_common(8)
+        ],
+    }
+
+    if len(ordered) < 2:
+        interpretation = "Only one observation is available; collect more history to estimate a trend."
+    elif direction == "worsening":
+        interpretation = "Recent sequential history suggests increasing predicted risk."
+    elif direction == "improving":
+        interpretation = "Recent sequential history suggests decreasing predicted risk."
+    else:
+        interpretation = "Sequential history is relatively stable."
+
+    return {
+        "disease": disease,
+        "observation_count": len(ordered),
+        "trend": {
+            "direction": direction if len(ordered) > 1 else "insufficient_data",
+            "slope_per_observation": round(slope, 4),
+            "probability_delta": round(probability_delta, 4),
+            "probability_delta_percent": round(probability_delta * 100, 2),
+            "volatility": round(volatility, 4),
+        },
+        "recent_weighted_probability": round(_clamp_probability(recent_weighted), 4),
+        "recent_weighted_probability_percent": round(_clamp_probability(recent_weighted) * 100, 2),
+        "latest_probability": round(_clamp_probability(latest_probability), 4),
+        "latest_probability_percent": round(_clamp_probability(latest_probability) * 100, 2),
+        "timeline": timeline,
+        "symptom_progression": symptom_progression,
+        "dynamic_updates": dynamic_updates,
+        "interpretation": interpretation,
+    }

--- a/backend/routes/doctor_routes.py
+++ b/backend/routes/doctor_routes.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import func
 from backend import db
 from backend.models.prediction import PredictionHistory
+from backend.analysis.temporal_progression import analyze_temporal_progression
 
 doctor_bp = Blueprint(
     'doctor',
@@ -204,6 +205,8 @@ def get_patient_dashboard_data(user_id):
     
     # Convert predictions to dict list
     predictions_list = [pred.to_dict() for pred in user_predictions]
+
+    temporal_progression = analyze_temporal_progression(user_predictions)
         
     return {
         'statistics': {
@@ -216,6 +219,7 @@ def get_patient_dashboard_data(user_id):
         },
         'predictions': predictions_list,
         'risk_distribution': risk_distribution,
+        'temporal_progression': temporal_progression,
         'last_updated': datetime.utcnow().isoformat()
     }
 

--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -4,6 +4,7 @@ from backend.models.ml_model import ml_model
 from backend.preprocessing import PreprocessingError, clean_prediction_payload
 from backend.utils.calculator import BayesCalculator
 from backend.models.prediction import PredictionHistory
+from backend.analysis.temporal_progression import analyze_temporal_progression
 from backend import db
 import json
 import traceback
@@ -78,6 +79,8 @@ def predict_disease():
         risk_level_map = {'Low': 'low', 'Moderate': 'medium', 'High': 'high', 'Critical': 'critical'}
         risk_level_db = risk_level_map.get(risk_assessment['level'], 'medium')
         
+        prediction_record = None
+
         # Save prediction to database
         try:
             prediction_record = PredictionHistory(
@@ -120,6 +123,16 @@ def predict_disease():
             },
             'risk_assessment': risk_assessment
         }
+
+        if current_user.is_authenticated and prediction_record is not None:
+            history = PredictionHistory.query.filter_by(
+                user_id=current_user.id,
+                disease=disease,
+            ).order_by(PredictionHistory.created_at.asc()).all()
+            result['temporal_progression'] = analyze_temporal_progression(
+                history,
+                disease=disease,
+            )
         
         return jsonify(result), 200
         
@@ -269,6 +282,46 @@ def get_all_symptoms():
         
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+@ml_bp.route('/api/ml/temporal-progress', methods=['GET'])
+def get_temporal_progress():
+    """
+    Analyze disease progression over sequential prediction history.
+
+    Optional query params:
+        disease: Limit progression analysis to one disease key/name.
+        Authenticated users receive their own history. Anonymous users receive
+        only anonymous prediction history.
+    """
+    try:
+        disease = request.args.get('disease')
+
+        query = PredictionHistory.query
+
+        if disease:
+            disease_key = ml_model._get_disease_key(disease)
+            query = query.filter(PredictionHistory.disease == disease_key)
+        else:
+            disease_key = None
+
+        if current_user.is_authenticated:
+            query = query.filter(PredictionHistory.user_id == current_user.id)
+        else:
+            query = query.filter(PredictionHistory.user_id.is_(None))
+
+        predictions = query.order_by(PredictionHistory.created_at.asc()).all()
+        progression = analyze_temporal_progression(predictions, disease=disease_key)
+
+        return jsonify({
+            'success': True,
+            'temporal_progression': progression,
+        }), 200
+
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
+    except Exception as e:
+        return jsonify({'error': f'Temporal progression analysis failed: {str(e)}'}), 500
 
 
 @ml_bp.route('/api/ml/symptom-importance/<disease>', methods=['GET'])

--- a/backend/templates/patient_dashboard.html
+++ b/backend/templates/patient_dashboard.html
@@ -230,6 +230,59 @@
             </div>
         </div>
 
+        <!-- Temporal Progression Row -->
+        <div class="row g-4 mb-4">
+            <div class="col-lg-8">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-header bg-transparent border-0 pt-4 pb-0">
+                        <h5 class="mb-0">
+                            <i class="fas fa-chart-line me-2"></i>Temporal Progression
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <div id="progression-empty-state" class="text-center py-5 d-none">
+                            <i class="fas fa-chart-line fa-3x text-muted opacity-50 mb-3"></i>
+                            <p class="text-muted">Add more predictions over time to see progression trends.</p>
+                        </div>
+                        <canvas id="progression-chart" height="260"></canvas>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-lg-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-header bg-transparent border-0 pt-4 pb-0">
+                        <h5 class="mb-0">
+                            <i class="fas fa-notes-medical me-2"></i>Progression Summary
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <span class="text-muted">Trend</span>
+                            <span class="badge bg-secondary text-uppercase" id="progression-trend">--</span>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <span class="text-muted">Recent Weighted Risk</span>
+                            <span class="fw-bold" id="recent-weighted-risk">--</span>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <span class="text-muted">Change Since First</span>
+                            <span class="fw-bold" id="progression-delta">--</span>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <span class="text-muted">Observations</span>
+                            <span class="fw-bold" id="progression-count">--</span>
+                        </div>
+                        <div class="pt-3 border-top">
+                            <p class="small text-muted mb-2" id="progression-interpretation">--</p>
+                            <small class="text-muted d-block">New symptoms: <span id="new-symptoms">--</span></small>
+                            <small class="text-muted d-block">Resolved symptoms: <span id="resolved-symptoms">--</span></small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Prediction History Table -->
         <div class="card border-0 shadow-sm mb-4">
             <div class="card-header bg-transparent border-0 pt-4">
@@ -312,6 +365,7 @@
 
 <script>
 let riskChart = null;
+let progressionChart = null;
 let allPredictions = [];
 let filteredPredictions = [];
 let currentPage = 1;
@@ -384,9 +438,105 @@ function updateDashboard(data) {
         
         // Update chart
         updateRiskChart(dist);
+        updateProgression(data.temporal_progression);
         
         // Render table
         renderPredictionsTable();
+    }
+}
+
+function formatSymptomList(symptoms) {
+    if (!symptoms || symptoms.length === 0) return 'None';
+    return symptoms.slice(0, 3).map(symptom => symptom.replaceAll('_', ' ')).join(', ');
+}
+
+function updateProgression(progression) {
+    const canvas = document.getElementById('progression-chart');
+    const emptyState = document.getElementById('progression-empty-state');
+    const hasTimeline = progression && progression.timeline && progression.timeline.length > 0;
+
+    if (!hasTimeline) {
+        emptyState.classList.remove('d-none');
+        canvas.classList.add('d-none');
+        return;
+    }
+
+    emptyState.classList.add('d-none');
+    canvas.classList.remove('d-none');
+
+    const trend = progression.trend || {};
+    const trendLabel = trend.direction || 'insufficient_data';
+    const trendClass = {
+        worsening: 'bg-danger',
+        improving: 'bg-success',
+        stable: 'bg-info',
+        insufficient_data: 'bg-secondary'
+    }[trendLabel] || 'bg-secondary';
+
+    const trendBadge = document.getElementById('progression-trend');
+    trendBadge.className = `badge ${trendClass} text-uppercase`;
+    trendBadge.textContent = trendLabel.replaceAll('_', ' ');
+    document.getElementById('recent-weighted-risk').textContent = `${progression.recent_weighted_probability_percent.toFixed(1)}%`;
+    document.getElementById('progression-delta').textContent = `${trend.probability_delta_percent.toFixed(1)}%`;
+    document.getElementById('progression-count').textContent = progression.observation_count;
+    document.getElementById('progression-interpretation').textContent = progression.interpretation;
+    document.getElementById('new-symptoms').textContent = formatSymptomList(progression.symptom_progression.new_symptoms);
+    document.getElementById('resolved-symptoms').textContent = formatSymptomList(progression.symptom_progression.resolved_symptoms);
+
+    const labels = progression.timeline.map(point => new Date(point.created_at).toLocaleDateString());
+    const visitRisk = progression.timeline.map(point => point.probability_percent);
+    const weightedRisk = progression.dynamic_updates.map(point => point.updated_probability * 100);
+
+    const chartData = {
+        labels,
+        datasets: [
+            {
+                label: 'Visit Risk',
+                data: visitRisk,
+                borderColor: 'rgba(13, 110, 253, 1)',
+                backgroundColor: 'rgba(13, 110, 253, 0.12)',
+                tension: 0.25,
+                fill: true
+            },
+            {
+                label: 'Recent Weighted Risk',
+                data: weightedRisk,
+                borderColor: 'rgba(25, 135, 84, 1)',
+                backgroundColor: 'rgba(25, 135, 84, 0.08)',
+                borderDash: [6, 4],
+                tension: 0.25
+            }
+        ]
+    };
+
+    const chartOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+            y: {
+                min: 0,
+                max: 100,
+                ticks: {
+                    callback: value => `${value}%`
+                }
+            }
+        },
+        plugins: {
+            legend: {
+                position: 'bottom'
+            }
+        }
+    };
+
+    if (progressionChart) {
+        progressionChart.data = chartData;
+        progressionChart.update();
+    } else {
+        progressionChart = new Chart(canvas.getContext('2d'), {
+            type: 'line',
+            data: chartData,
+            options: chartOptions
+        });
     }
 }
 

--- a/backend/tests/test_temporal_progression.py
+++ b/backend/tests/test_temporal_progression.py
@@ -1,0 +1,97 @@
+import json
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+from backend import create_app, db
+from backend.analysis.temporal_progression import analyze_temporal_progression
+from backend.models.prediction import PredictionHistory
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("SECRET_KEY", "test-secret-key")
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    app = create_app()
+    app.config["TESTING"] = True
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def make_prediction(offset_days, probability, risk_level, symptoms):
+    return PredictionHistory(
+        disease="diabetes",
+        symptoms=json.dumps(symptoms),
+        ml_probability=probability,
+        bayesian_posterior=probability,
+        risk_level=risk_level,
+        patient_age=42,
+        created_at=datetime.utcnow() + timedelta(days=offset_days),
+    )
+
+
+def test_temporal_progression_detects_worsening_sequence():
+    predictions = [
+        make_prediction(0, 0.25, "low", ["fatigue"]),
+        make_prediction(1, 0.48, "medium", ["fatigue", "increased_thirst"]),
+        make_prediction(2, 0.72, "high", ["fatigue", "increased_thirst", "blurred_vision"]),
+    ]
+
+    progression = analyze_temporal_progression(predictions, disease="diabetes")
+
+    assert progression["observation_count"] == 3
+    assert progression["trend"]["direction"] == "worsening"
+    assert progression["trend"]["probability_delta"] == 0.47
+    assert progression["recent_weighted_probability"] > 0.48
+    assert progression["symptom_progression"]["new_symptoms"] == [
+        "blurred_vision",
+        "increased_thirst",
+    ]
+    assert progression["timeline"][1]["risk_transition"] == "escalated"
+    assert len(progression["dynamic_updates"]) == 3
+
+
+def test_temporal_progression_detects_improving_sequence():
+    predictions = [
+        make_prediction(0, 0.78, "high", ["fatigue", "blurred_vision"]),
+        make_prediction(1, 0.52, "medium", ["fatigue"]),
+        make_prediction(2, 0.28, "low", ["fatigue"]),
+    ]
+
+    progression = analyze_temporal_progression(predictions, disease="diabetes")
+
+    assert progression["trend"]["direction"] == "improving"
+    assert progression["timeline"][1]["risk_transition"] == "deescalated"
+    assert progression["symptom_progression"]["resolved_symptoms"] == ["blurred_vision"]
+
+
+def test_temporal_progression_handles_empty_history():
+    progression = analyze_temporal_progression([], disease="diabetes")
+
+    assert progression["observation_count"] == 0
+    assert progression["trend"]["direction"] == "insufficient_data"
+    assert progression["timeline"] == []
+
+
+def test_temporal_progression_api_returns_anonymous_history(client, app):
+    with app.app_context():
+        db.session.add(make_prediction(0, 0.22, "low", ["fatigue"]))
+        db.session.add(make_prediction(1, 0.64, "high", ["fatigue", "increased_thirst"]))
+        db.session.commit()
+
+    response = client.get("/api/ml/temporal-progress?disease=diabetes")
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data["success"] is True
+    assert data["temporal_progression"]["observation_count"] == 2
+    assert data["temporal_progression"]["trend"]["direction"] == "worsening"


### PR DESCRIPTION
## Summary
- add temporal progression analysis over sequential prediction history
- expose progression through the ML temporal-progress API and prediction responses for authenticated users
- surface trend, recent-weighted risk, dynamic probability updates, and symptom changes on the patient dashboard
- add focused tests for worsening/improving/empty progression histories and the API response

Closes #253

## Testing
- python3 -m py_compile backend/analysis/temporal_progression.py backend/routes/ml_routes.py backend/routes/doctor_routes.py backend/tests/test_temporal_progression.py
- direct analyzer smoke test via importlib

Note: Full pytest run was not possible locally because the system Python environment is missing pytest and Flask.