### PR TITLE
fix: apply dark mode CSS variables to dashboard dropdown

### DIFF
--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -97,8 +97,8 @@
             right: 0;
             margin-top: 0.5rem;
             min-width: 220px;
-            background: #ffffff;
-            border: 1px solid #dee2e6;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-color);
             border-radius: 0.5rem;
             box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
             display: none;
@@ -114,7 +114,7 @@
             display: flex;
             align-items: center;
             padding: 0.75rem 1rem;
-            color: #34495e;
+            color: var(--text-primary);
             text-decoration: none;
             transition: background 0.2s ease;
         }


### PR DESCRIPTION
## Description
Fixes the dark mode issue where the dashboard hamburger dropdown menu was not reflecting the dark theme.

## Related Issues
Fixes #292

## Changes Summary
- Replaced hardcoded `#ffffff` background with `var(--bg-secondary)`
- Replaced hardcoded `#dee2e6` border with `var(--border-color)`
- Replaced hardcoded `#34495e` text color with `var(--text-primary)`