### PR TITLE
fix: apply dark mode styling to dashboard dropdown menu

### DIFF
--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -146,6 +146,29 @@
             letter-spacing: 0.05em;
         }
 
+
+        body.dark-mode .dashboard-dropdown {
+            background: #212529;
+            border-color: #373b3e;
+        }
+
+        body.dark-mode .dashboard-dropdown-item {
+            color: #f8f9fa;
+        }
+
+        body.dark-mode .dashboard-dropdown-item:hover {
+            background: rgba(26, 188, 156, 0.2);
+            color: #1abc9c;
+        }
+
+        body.dark-mode .dashboard-dropdown-divider {
+            background: #373b3e;
+        }
+
+        body.dark-mode .dashboard-dropdown-label {
+            color: #adb5bd;
+        }
+
         @media (max-width: 991.98px) {
 
             /* On mobile, make the dashboard dropdown part of the vertical flow */


### PR DESCRIPTION
## 📄 Description
This PR resolves a UI bug where the global dashboard dropdown menu remained hardcoded with a white background and dark text when the application's Dark Mode was toggled. The dropdown now seamlessly respects the application's `dark-mode` state, improving UI consistency and accessibility.

*Contributing as part of **GirlScript Summer of Code (GSSoC) 2026**.*

## 🔗 Related Issues
> Fixes #292

## ✨ Changes Summary
- Added dark mode CSS overrides for the `.dashboard-dropdown` container in `backend/templates/base.html`.
- Styled `.dashboard-dropdown-item` text and hover states to match the existing dark theme palette (`#212529` background, `#f8f9fa` text).
- Updated the dropdown divider and label colors for dark mode visibility.

## 📸 Screenshots 
**Before:**
<img width="323" height="587" alt="Screenshot 2026-05-20 at 7 48 13 AM" src="https://github.com/user-attachments/assets/23335b9b-2b1b-4bad-a949-684ea4c22cf7" />

**After:**
<img width="324" height="560" alt="Screenshot 2026-05-20 at 4 44 24 PM" src="https://github.com/user-attachments/assets/cf274918-445f-489e-bbd5-a1726818c35d" />

## ✅ Checklist
- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings
