### PR TITLE
feat: enhance SHAP explainability with positive/negative contributions and explain endpoint

### DIFF
--- a/backend/models/ml_model.py
+++ b/backend/models/ml_model.py
@@ -179,28 +179,58 @@ class DiseaseMLModel:
         raise ValueError(f"Disease '{disease_name}' (key: {disease_key}) not found in model")
 
     def compute_shap_values(self, disease_key: str, symptoms: List[str]) -> Dict:
-        """Compute symptom contribution scores for the prediction."""
-
+        """
+        Compute SHAP-style symptom contribution scores for explainability.
+        Uses a linear approximation:
+        - Baseline = expected value with no symptoms (bias only)
+        - Each symptom contribution = weight * (1 - baseline_probability)
+        - Negative contributions shown for high-weight missing symptoms
+        """
         symptom_weights = self.disease_weights[disease_key]["symptoms"]
+        bias = self.disease_weights[disease_key]["bias"]
 
-        # Simple baseline assumption:
-        # symptom has 50% chance of appearing
-        baseline = 0.5
+        # Baseline probability with no symptoms
+        baseline_prob = self.calibrated_sigmoid(bias)
 
         shap_values = {}
 
+        # Positive contributions from present symptoms
         for symptom in symptoms:
             weight = symptom_weights.get(symptom)
-
             if weight is None:
                 continue
+            contribution = round(weight * (1 - baseline_prob), 4)
+            shap_values[symptom] = {
+                "contribution": contribution,
+                "weight": weight,
+                "direction": "positive",
+                "display_name": self.symptom_display_names.get(
+                    symptom, symptom.replace('_', ' ').title()
+                )
+            }
 
-            # symptom is selected => x = 1
-            contribution = weight * (1 - baseline)
+        # Negative contributions from important absent symptoms
+        for symptom_key, weight in symptom_weights.items():
+            if symptom_key not in symptoms and weight >= 0.80:
+                contribution = round(-weight * baseline_prob * 0.5, 4)
+                shap_values[symptom_key] = {
+                    "contribution": contribution,
+                    "weight": weight,
+                    "direction": "negative",
+                    "display_name": self.symptom_display_names.get(
+                        symptom_key, symptom_key.replace('_', ' ').title()
+                    )
+                }
 
-            shap_values[symptom] = round(contribution, 4)
+        # Sort by absolute contribution descending
+        sorted_shap = dict(
+            sorted(shap_values.items(),
+                   key=lambda x: abs(x[1]["contribution"]),
+                   reverse=True)
+        )
 
-        return shap_values
+        # Return top 10 contributions
+        return dict(list(sorted_shap.items())[:10])
 
     def predict_disease_probability(self, disease: str, symptoms: List[str], age: int = None, height_cm: float = None, weight_kg: float = None) -> Dict:
         """Predict disease probability based on selected symptoms."""

--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -471,6 +471,70 @@ def get_uncertainty_config():
     return jsonify(uncertainty_handler.get_config()), 200
  
  
+
+@ml_bp.route('/api/ml/explain', methods=['POST'])
+def explain_prediction():
+    """SHAP-based prediction explainability endpoint."""
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({'error': 'No data provided'}), 400
+
+        disease = data.get('disease', '').lower().replace(' ', '_')
+        symptoms = data.get('symptoms', [])
+
+        if not disease:
+            return jsonify({'error': 'Disease not specified'}), 400
+        if not symptoms:
+            return jsonify({'error': 'No symptoms provided'}), 400
+
+        disease_key = ml_model._get_disease_key(disease)
+        prediction = ml_model.predict_disease_probability(disease, symptoms)
+        shap_values = ml_model.compute_shap_values(disease_key, symptoms)
+
+        positive = {k: v for k, v in shap_values.items() if v["direction"] == "positive"}
+        negative = {k: v for k, v in shap_values.items() if v["direction"] == "negative"}
+
+        top_positive = sorted(
+            positive.items(),
+            key=lambda x: x[1]["contribution"],
+            reverse=True
+        )[:3]
+
+        summary_parts = [
+            f"{v['display_name']} (+{v['contribution']:.2f})"
+            for _, v in top_positive
+        ]
+        summary = (
+            f"Top contributing symptoms: {', '.join(summary_parts)}"
+            if summary_parts
+            else "No strong symptom contributions found."
+        )
+
+        return jsonify({
+            'success': True,
+            'disease': disease.replace('_', ' ').title(),
+            'calibrated_probability': round(
+                prediction['calibrated_probability'] * 100, 2
+            ),
+            'explanation': {
+                'shap_values': shap_values,
+                'positive_contributions': positive,
+                'negative_contributions': negative,
+                'summary': summary,
+                'baseline_info': (
+                    'Positive values increase disease probability. '
+                    'Negative values indicate important absent symptoms.'
+                )
+            }
+        }), 200
+
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
+    except Exception as e:
+        return jsonify({'error': f'Explanation failed: {str(e)}'}), 500
+
+
 def get_risk_level(probability):
     """
     Determine risk level based on probability percentage.


### PR DESCRIPTION
## What this PR does
Closes #280

## Changes made

### backend/models/ml_model.py
- Enhanced compute_shap_values() with proper baseline 
  probability calculation using calibrated_sigmoid
- Added positive contributions for present symptoms
- Added negative contributions for important absent symptoms
- Returns top 10 contributions sorted by absolute value
- Each contribution includes display_name and direction

### backend/routes/ml.py
- Added new POST /api/ml/explain endpoint
- Returns structured SHAP explanation with positive/negative 
  split, summary text, and baseline info
- Compatible with existing prediction pipeline

### requirements.txt
- Added shap>=0.44.0

## Type of change
- [x] Feature / Enhancement