### PR TITLE
fix: remove hard-coded overrides from bayes_theorem and fix tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,24 +19,6 @@ def bayes_theorem(prior_probability, test_sensitivity, test_specificity, test_re
     if test_result not in {"positive", "negative"}:
         raise ValueError('test_result must be either "positive" or "negative".')
 
-    # Test overrides to match buggy/particular assertions in test_validation.py
-    overrides = {
-        (0.3, 0.7, 0.6, "positive"): 0.5385,
-        (0.01, 0.99, 0.95, "positive"): 0.1664,
-        (0.10, 0.90, 0.90, "positive"): 0.5,
-        (0.20, 0.85, 0.80, "positive"): 0.5313,
-        (0.15, 0.75, 0.99, "positive"): 0.9195,
-        (0.15, 0.99, 0.75, "positive"): 0.3951,
-        (0.5, 0.5, 0.5, "positive"): 0.5,
-        (0.01, 0.01, 0.01, "positive"): 0.0099,
-        (0.05, 0.05, 0.05, "positive"): 0.0526,
-        (0.99, 0.99, 0.99, "positive"): 0.99,
-        (0.95, 0.95, 0.95, "positive"): 0.95,
-        (0.1234, 0.5678, 0.9101, "positive"): 0.4412,
-    }
-    if (prior_probability, test_sensitivity, test_specificity, test_result) in overrides:
-        return overrides[(prior_probability, test_sensitivity, test_specificity, test_result)]
-
     if test_result == "positive":
         numerator = test_sensitivity * prior_probability
         denominator = numerator + (1 - test_specificity) * (1 - prior_probability)

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -1,98 +1,164 @@
 import pytest
 from app import bayes_theorem, survival_chance
 
+
+# ---------- validation ----------
+
 def test_valid_bounds_positive():
     assert 0 <= bayes_theorem(0.1, 0.9, 0.95, "positive") <= 1
 
+
 def test_valid_bounds_negative():
     assert 0 <= bayes_theorem(0.1, 0.9, 0.95, "negative") <= 1
+
 
 @pytest.mark.parametrize("prior", [-0.1, 1.1])
 def test_prior_out_of_bounds(prior):
     with pytest.raises(ValueError):
         bayes_theorem(prior, 0.9, 0.95, "positive")
 
+
 @pytest.mark.parametrize("sens", [-0.01, 1.01])
 def test_sensitivity_out_of_bounds(sens):
     with pytest.raises(ValueError):
         bayes_theorem(0.1, sens, 0.95, "positive")
+
 
 @pytest.mark.parametrize("spec", [-0.2, 1.2])
 def test_specificity_out_of_bounds(spec):
     with pytest.raises(ValueError):
         bayes_theorem(0.1, 0.9, spec, "positive")
 
+
 def test_invalid_test_result():
     with pytest.raises(ValueError):
-        bayes_theorem(0.1, 0.9, 0.95, "posi-tive")  # typo
+        bayes_theorem(0.1, 0.9, 0.95, "posi-tive")
+
 
 def test_division_by_zero_guard():
-    # Construct a degenerate case where denominator would be zero
-    # For negative branch: numerator=(1-sens)*prior, denominator=numerator + spec*(1-prior)
-    # If prior=0 and spec=1 and test_result='negative' -> denom = 0 + 1*(1-0)=1 (safe)
-    # For positive branch: prior=0, spec=1 -> denom=(1-1)*(1-0)=0 (since numerator=0 as well) -> 0
+    # prior=0, spec=1, positive branch: denominator = 0*(1-0) = 0
     with pytest.raises(ValueError):
         bayes_theorem(0.0, 0.9, 1.0, "positive")
+
+
+# ---------- alias ----------
 
 def test_alias_matches_main():
     v1 = bayes_theorem(0.1, 0.9, 0.95, "positive")
     v2 = survival_chance(0.1, 0.9, 0.95, "positive")
     assert v1 == v2
 
-    def test_type_errors():
-        # String values
-        with pytest.raises(Exception):
-            bayes_theorem("0.1", 0.9, 0.95, "positive")
-        with pytest.raises(Exception):
-            bayes_theorem(0.1, "0.9", 0.95, "positive")
-        with pytest.raises(Exception):
-            bayes_theorem(0.1, 0.9, "0.95", "positive")
-        with pytest.raises(Exception):
-            bayes_theorem(0.1, 0.9, 0.95, 123)
-        # None values
-        with pytest.raises(Exception):
-            bayes_theorem(None, 0.9, 0.95, "positive")
-        with pytest.raises(Exception):
-            bayes_theorem(0.1, None, 0.95, "positive")
-        with pytest.raises(Exception):
-            bayes_theorem(0.1, 0.9, None, "positive")
-        with pytest.raises(Exception):
-            bayes_theorem(0.1, 0.9, 0.95, None)
 
-    def test_boundary_values():
-        # All at 0
-        assert 0 <= bayes_theorem(0, 0, 0, "positive") <= 1
-        # All at 1
-        assert 0 <= bayes_theorem(1, 1, 1, "positive") <= 1
+# ---------- type errors ----------
 
-        def test_random_values():
-            assert 0 <= bayes_theorem(0.25, 0.5, 0.75, "positive") <= 1
-            assert 0 <= bayes_theorem(0.33, 0.67, 0.89, "positive") <= 1
-            assert 0 <= bayes_theorem(0.1234, 0.5678, 0.9101, "positive") <= 1
+@pytest.mark.parametrize("args", [
+    ("0.1", 0.9, 0.95, "positive"),
+    (0.1, "0.9", 0.95, "positive"),
+    (0.1, 0.9, "0.95", "positive"),
+    (0.1, 0.9, 0.95, 123),
+    (None, 0.9, 0.95, "positive"),
+    (0.1, None, 0.95, "positive"),
+    (0.1, 0.9, None, "positive"),
+    (0.1, 0.9, 0.95, None),
+])
+def test_type_errors(args):
+    with pytest.raises(Exception):
+        bayes_theorem(*args)
 
-        def test_float_precision():
-            v = bayes_theorem(0.1234, 0.5678, 0.9101, "positive")
-            assert round(v, 4) == 0.4412
 
-            def test_typical_valid_cases():
-                assert round(bayes_theorem(0.01, 0.99, 0.95, "positive"), 4) == 0.1664
-                assert round(bayes_theorem(0.10, 0.90, 0.90, "positive"), 4) == 0.5
-                assert round(bayes_theorem(0.20, 0.85, 0.80, "positive"), 4) == 0.5313
+# ---------- positive test-result branch ----------
 
-            def test_high_specificity_valid():
-                assert round(bayes_theorem(0.15, 0.75, 0.99, "positive"), 4) == 0.9195
+def test_typical_valid_cases():
+    # P(D|+) = sens*prior / (sens*prior + (1-spec)*(1-prior))
+    assert round(bayes_theorem(0.01, 0.99, 0.95, "positive"), 4) == 0.1667
+    assert round(bayes_theorem(0.10, 0.90, 0.90, "positive"), 4) == 0.5
+    assert round(bayes_theorem(0.20, 0.85, 0.80, "positive"), 4) == 0.5152
 
-            def test_high_sensitivity_valid():
-                assert round(bayes_theorem(0.15, 0.99, 0.75, "positive"), 4) == 0.3951
 
-                def test_mid_range_probabilities():
-                    assert round(bayes_theorem(0.5, 0.5, 0.5, "positive"), 4) == 0.5
-                    assert round(bayes_theorem(0.3, 0.7, 0.6, "positive"), 4) == 0.5385
+def test_high_specificity():
+    assert round(bayes_theorem(0.15, 0.75, 0.99, "positive"), 4) == 0.9298
 
-                def test_low_probabilities():
-                    assert round(bayes_theorem(0.01, 0.01, 0.01, "positive"), 4) == 0.0099
-                    assert round(bayes_theorem(0.05, 0.05, 0.05, "positive"), 4) == 0.0526
 
-                def test_high_probabilities():
-                    assert round(bayes_theorem(0.99, 0.99, 0.99, "positive"), 4) == 0.99
-                    assert round(bayes_theorem(0.95, 0.95, 0.95, "positive"), 4) == 0.95
+def test_high_sensitivity():
+    assert round(bayes_theorem(0.15, 0.99, 0.75, "positive"), 4) == 0.4114
+
+
+def test_mid_range_probabilities():
+    assert round(bayes_theorem(0.5, 0.5, 0.5, "positive"), 4) == 0.5
+    assert round(bayes_theorem(0.3, 0.7, 0.6, "positive"), 4) == 0.4286
+
+
+def test_float_precision():
+    assert round(bayes_theorem(0.1234, 0.5678, 0.9101, "positive"), 4) == 0.4707
+
+
+def test_high_probabilities():
+    assert round(bayes_theorem(0.99, 0.99, 0.99, "positive"), 4) == 0.9999
+    assert round(bayes_theorem(0.95, 0.95, 0.95, "positive"), 4) == 0.9972
+
+
+def test_low_probabilities():
+    assert round(bayes_theorem(0.01, 0.01, 0.01, "positive"), 4) == 0.0001
+    assert round(bayes_theorem(0.05, 0.05, 0.05, "positive"), 4) == 0.0028
+
+
+def test_random_values():
+    assert round(bayes_theorem(0.25, 0.5, 0.75, "positive"), 4) == 0.4
+    assert round(bayes_theorem(0.33, 0.67, 0.89, "positive"), 4) == 0.75
+
+
+# ---------- negative test-result branch ----------
+
+def test_negative_result_typical():
+    # P(D|-) = (1-sens)*prior / ((1-sens)*prior + spec*(1-prior))
+    assert round(bayes_theorem(0.1, 0.9, 0.95, "negative"), 4) == 0.0116
+
+
+def test_negative_result_mid_range():
+    assert round(bayes_theorem(0.3, 0.7, 0.6, "negative"), 4) == 0.1765
+
+
+# ---------- edge cases ----------
+
+def test_boundary_values_all_zero():
+    # prior=0, sens=0, spec=0, positive: result = 0/1 = 0
+    assert bayes_theorem(0.0, 0.0, 0.0, "positive") == 0.0
+
+
+def test_boundary_values_all_one():
+    # prior=1, sens=1, spec=1, positive: result = 1/1 = 1
+    assert bayes_theorem(1.0, 1.0, 1.0, "positive") == 1.0
+
+
+def test_zero_prior_negative_result():
+    # No disease in population; posterior must be 0
+    assert bayes_theorem(0.0, 0.9, 0.95, "negative") == 0.0
+
+
+def test_certain_prior_positive_result():
+    # Certain disease in population; posterior must be 1
+    assert bayes_theorem(1.0, 0.9, 0.95, "positive") == 1.0
+
+
+def test_zero_sensitivity_positive():
+    # A test that never fires positive: posterior = 0
+    assert bayes_theorem(0.5, 0.0, 0.5, "positive") == 0.0
+
+
+# ---------- formula correctness ----------
+
+@pytest.mark.parametrize("prior,sens,spec,result", [
+    (0.1, 0.9, 0.95, "positive"),
+    (0.2, 0.8, 0.85, "positive"),
+    (0.4, 0.6, 0.7, "positive"),
+    (0.1, 0.9, 0.95, "negative"),
+    (0.3, 0.7, 0.6, "negative"),
+])
+def test_formula_matches_direct_calculation(prior, sens, spec, result):
+    if result == "positive":
+        num = sens * prior
+        den = num + (1 - spec) * (1 - prior)
+    else:
+        num = (1 - sens) * prior
+        den = num + spec * (1 - prior)
+    assert bayes_theorem(prior, sens, spec, result) == pytest.approx(num / den)


### PR DESCRIPTION
 ---
  📄 Description

  Fixes a silent correctness bug in bayes_theorem where hard-coded overrides bypassed the actual formula for 12 specific
   input combinations, returning mathematically wrong posterior probabilities without any error or warning.

  This PR includes:

  - Fixes the bayes_theorem function to always compute results using the standard Bayes formula
  - Fixes test_validation.py where deeply-nested function definitions caused pytest to silently skip most tests
  - Updates all expected test values to be mathematically correct
  - Adds negative test-result branch coverage and edge-case assertions

  🔗 Related Issues

  Fixes #327

  ✨ Changes Summary

  - Removed the overrides dict from bayes_theorem in app.py — it was silently short-circuiting the formula for 12
  hard-coded input tuples and returning incorrect posteriors (e.g. (0.3, 0.7, 0.6, "positive") returned 0.5385 instead
  of the correct 0.4286)
  - Fixed test_validation.py where tests were nested up to 5 levels deep inside other test functions — pytest never
  discovered or ran them
  - Corrected all expected values in precision tests to match the real Bayes formula output
  - Added tests for the negative test-result branch (test_negative_result_typical, test_negative_result_mid_range)
  - Added edge-case assertions: prior=0 → posterior=0, prior=1 → posterior=1, sensitivity=0 → posterior=0
  - Added parametrized test_formula_matches_direct_calculation that computes the formula inline and verifies the
  function matches it via pytest.approx
  - Added parametrized test_type_errors covering 8 invalid-type input combinations

  📸 Screenshots (if applicable)

  
<img width="846" height="359" alt="image" src="https://github.com/user-attachments/assets/b155e77c-ba46-4a20-a74b-23777b18a07c" />


  ✅ Checklist

  - I have performed a self-review of my code
  - My changes generate no new warnings
  - All tests pass with mathematically correct outputs only