### PR TITLE
fix: redirect /connect to /contact and fix broken privacy link

### DIFF
--- a/backend/routes/general_routes.py
+++ b/backend/routes/general_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, current_app
+from flask import Blueprint, render_template, current_app, redirect, url_for
 
 general_bp = Blueprint(
     'general',
@@ -25,7 +25,7 @@ def terms():
 
 @general_bp.route('/connect')
 def connect():
-    return render_template('connect.html')
+    return redirect(url_for('disease.contact'))
 
 @general_bp.route('/service-worker.js')
 def service_worker():

--- a/backend/templates/privacy.html
+++ b/backend/templates/privacy.html
@@ -51,7 +51,7 @@
 
         <h2>6. Contact Us</h2>
         <p>If you have any questions about this privacy policy or our privacy practices, please contact us via our <a
-                href="{{ url_for('general.connect') }}">Connect</a> page.</p>
+                href="{{ url_for('disease.contact') }}">Connect</a> page.</p>
     </div>
 </div>
 {% endblock %}

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -199,3 +199,17 @@ def test_custom_disease_calculation(client):
                     response = json.loads(rv.data)
                     assert 'p_d_given_pos' in response
                     assert round(response['p_d_given_pos'], 4) == 0.95
+
+
+def test_contact_page(client):
+    """Test if contact page loads correctly"""
+    rv = client.get('/contact')
+    assert rv.status_code == 200
+    assert b'Connect With Us' in rv.data
+
+
+def test_connect_redirects_to_contact(client):
+    """Test if /connect redirects to /contact"""
+    rv = client.get('/connect')
+    assert rv.status_code in (301, 302)
+    assert rv.location.endswith('/contact')


### PR DESCRIPTION
## Description

Fixes a `500 Internal Server Error` (`TemplateNotFound: connect.html`) 
on the `/connect` route. The route was registered in `general_routes.py` 
but the template `connect.html` never existed in the templates directory.
Additionally, the **Privacy Policy page** had a broken "Connect" link 
pointing to this dead route.

## Related Issue

Closes #304 

## Root Cause

The `/connect` route in `backend/routes/general_routes.py` called 
`render_template('connect.html')` but `connect.html` did not exist 
in `backend/templates/`. Meanwhile, `/contact` route already existed 
and served the same purpose with `contact.html` ("Connect With Us").

## Changes Made

| File | Change |
|---|---|
| `backend/routes/general_routes.py` | Changed `/connect` route to redirect to `disease.contact` instead of rendering missing `connect.html` |
| `backend/templates/privacy.html` | Updated "Connect" link from `general.connect` to `disease.contact` directly |
| `backend/tests/test_integration.py` | Added two integration tests to verify the fix |

## How to Test

**Manual Testing:**
1. Run `python run.py`
2. Visit `http://127.0.0.1:5001/connect` → Should redirect to `/contact` (no 500 error)
3. Visit `http://127.0.0.1:5001/privacy` → Click "Connect" link → Should open contact page

**Screenshot:**
<img width="1911" height="576" alt="image" src="https://github.com/user-attachments/assets/c0a4f6d9-21d1-47b5-91d1-cd3c746192ba" />

