### PR TITLE
feat: add direct height and weight inputs

### DIFF
--- a/backend/templates/home.html
+++ b/backend/templates/home.html
@@ -34,29 +34,44 @@
                         placeholder="Enter age (e.g. 45)" min="1" max="120">
                 </div>
 
-                <div class="mb-4">
-                    <label for="height-input" class="form-label">
-                        <i class="fas fa-ruler-vertical me-1"></i> Height (in cm)
-                    </label>
-                    <input type="range" id="height-input" class="form-range form-range-lg"
-                        placeholder="Enter height (e.g. 154)" value="170" min="50" max="280" step="1"
-                        oninput="updateHeight(this.value)">
-                    <div class="text-muted">
-                        <span id="height-value">170</span>cm
-                    </div>
-                </div>
+<div class="mb-4">
+    <label for="height-input" class="form-label">
+        <i class="fas fa-ruler-vertical me-1"></i> Height (in cm)
+    </label>
 
-                <div class="mb-4">
-                    <label for="weight-input" class="form-label">
-                        <i class="fas fa-ruler-vertical me-1"></i> Weight (in kg)
-                    </label>
-                    <input type="range" id="weight-input" class="form-range form-range-lg"
-                        placeholder="Enter weight (e.g. 67 kg)" value="60" min="2" max="170" step="1"
-                        oninput="updateWeight(this.value)">
-                    <div class="text-muted">
-                        <span id="weight-value">60</span>kg
-                    </div>
-                </div>
+    <input type="range" id="height-input" class="form-range form-range-lg"
+        value="170" min="50" max="250"
+        oninput="updateHeight(this.value)">
+
+    <input type="number" id="height-number" class="form-control mt-2"
+        placeholder="Enter height directly (e.g. 170)"
+        value="170" min="50" max="250"
+        oninput="updateHeight(this.value)">
+
+    <div class="text-muted">
+        <span id="height-value">170</span>cm
+    </div>
+</div>
+
+
+<div class="mb-4">
+    <label for="weight-input" class="form-label">
+        <i class="fas fa-weight me-1"></i> Weight (in kg)
+    </label>
+
+    <input type="range" id="weight-input" class="form-range form-range-lg"
+        value="60" min="2" max="170"
+        oninput="updateWeight(this.value)">
+
+    <input type="number" id="weight-number" class="form-control mt-2"
+        placeholder="Enter weight directly (e.g. 60)"
+        value="60" min="2" max="170"
+        oninput="updateWeight(this.value)">
+
+    <div class="text-muted">
+        <span id="weight-value">60</span>kg
+    </div>
+</div>
 
                 <div class="alert alert-info mt-3" id="bmi-box">
                     BMI: <strong id="bmi-value">—</strong>
@@ -694,34 +709,60 @@
     // =========================================================
     // HEIGHT / WEIGHT / BMI
     // =========================================================
-    function updateHeight(val) {
-        document.getElementById("height-value").innerText = val;
-        calculateBMI();
+function updateHeight(val) {
+    const heightRange = document.getElementById("height-input");
+    const heightNumber = document.getElementById("height-number");
+    const heightValue = document.getElementById("height-value");
+
+    heightRange.value = val;
+    heightNumber.value = val;
+    heightValue.innerText = val;
+
+    calculateBMI();
+}
+
+function updateWeight(val) {
+    const weightRange = document.getElementById("weight-input");
+    const weightNumber = document.getElementById("weight-number");
+    const weightValue = document.getElementById("weight-value");
+
+    weightRange.value = val;
+    weightNumber.value = val;
+    weightValue.innerText = val;
+
+    calculateBMI();
+}
+
+function calculateBMI() {
+    const h = document.getElementById("height-input").value / 100;
+    const w = document.getElementById("weight-input").value;
+
+    if (!h || !w) return;
+
+    const bmi = (w / (h * h)).toFixed(1);
+    document.getElementById("bmi-value").innerText = bmi;
+
+    let category = "Normal";
+    let badge = "bg-success";
+
+    if (bmi < 18.5) {
+        category = "Underweight";
+        badge = "bg-warning";
+    } else if (bmi < 25) {
+        category = "Normal";
+        badge = "bg-success";
+    } else if (bmi < 30) {
+        category = "Overweight";
+        badge = "bg-warning";
+    } else {
+        category = "Obese";
+        badge = "bg-danger";
     }
 
-    function updateWeight(val) {
-        document.getElementById("weight-value").innerText = val;
-        calculateBMI();
-    }
-
-    function calculateBMI() {
-        const h = document.getElementById("height-input").value / 100;
-        const w = document.getElementById("weight-input").value;
-        if (!h || !w) return;
-
-        const bmi = (w / (h * h)).toFixed(1);
-        document.getElementById("bmi-value").innerText = bmi;
-
-        let category = "Normal", badge = "bg-success";
-        if      (bmi < 18.5) { category = "Underweight"; badge = "bg-warning"; }
-        else if (bmi < 25)   { category = "Normal";      badge = "bg-success"; }
-        else if (bmi < 30)   { category = "Overweight";  badge = "bg-warning"; }
-        else                  { category = "Obese";       badge = "bg-danger";  }
-
-        const catEl = document.getElementById("bmi-category");
-        catEl.innerText = category;
-        catEl.className = `badge ${badge}`;
-    }
+    const catEl = document.getElementById("bmi-category");
+    catEl.innerText = category;
+    catEl.className = `badge ${badge}`;
+}
 
     let calibrationChart = null;
 

--- a/backend/templates/ml_prediction.html
+++ b/backend/templates/ml_prediction.html
@@ -33,29 +33,45 @@
                         placeholder="Enter age (e.g. 45)" min="1" max="120">
                 </div>
 
-                <div class="mb-4">
-                    <label for="height-input" class="form-label">
-                        <i class="fas fa-ruler-vertical me-1"></i> Height (in cm)
-                    </label>
-                    <input type="range" id="height-input" class="form-range form-range-lg"
-                        placeholder="Enter height (e.g. 154)" value="170" min="50" max="280" step="1"
-                        oninput="updateHeight(this.value)">
-                    <div class="text-muted">
-                        <span id="height-value">170</span>cm
-                    </div>
-                </div>
+          <div class="mb-4">
+    <label for="height-input" class="form-label">
+        <i class="fas fa-ruler-vertical me-1"></i> Height (in cm)
+    </label>
 
-                <div class="mb-4">
-                    <label for="weight-input" class="form-label">
-                        <i class="fas fa-ruler-vertical me-1"></i> Weight (in kg)
-                    </label>
-                    <input type="range" id="weight-input" class="form-range form-range-lg"
-                        placeholder="Enter weight (e.g. 67 kg)" value="60" min="2" max="170" step="1"
-                        oninput="updateWeight(this.value)">
-                    <div class="text-muted">
-                        <span id="weight-value">60</span>kg
-                    </div>
-                </div>
+    <input type="range" id="height-input" class="form-range form-range-lg"
+        value="170" min="50" max="250"
+        oninput="updateHeight(this.value)">
+
+    <input type="number" id="height-number" class="form-control mt-2"
+        placeholder="Enter height directly (e.g. 170)"
+        value="170" min="50" max="250"
+        oninput="updateHeight(this.value)">
+
+    <div class="text-muted">
+        <span id="height-value">170</span>cm
+    </div>
+</div>
+
+
+ <div class="mb-4">
+    <label for="weight-input" class="form-label">
+        <i class="fas fa-weight me-1"></i> Weight (in kg)
+    </label>
+
+    <input type="range" id="weight-input" class="form-range form-range-lg"
+        value="60" min="2" max="170"
+        oninput="updateWeight(this.value)">
+
+    <input type="number" id="weight-number" class="form-control mt-2"
+        placeholder="Enter weight directly (e.g. 60)"
+        value="60" min="2" max="170"
+        oninput="updateWeight(this.value)">
+
+    <div class="text-muted">
+        <span id="weight-value">60</span>kg
+    </div>
+</div>
+
 
                 <div class="alert alert-info mt-3" id="bmi-box">
                     BMI: <strong id="bmi-value">—</strong>
@@ -353,47 +369,60 @@
     }
 
     // height updation 
-    function updateHeight(val) {
-        document.getElementById("height-value").innerText = val;
-        calculateBMI();
+  function updateHeight(val) {
+    const heightRange = document.getElementById("height-input");
+    const heightNumber = document.getElementById("height-number");
+    const heightValue = document.getElementById("height-value");
+
+    heightRange.value = val;
+    heightNumber.value = val;
+    heightValue.innerText = val;
+
+    calculateBMI();
+}
+
+function updateWeight(val) {
+    const weightRange = document.getElementById("weight-input");
+    const weightNumber = document.getElementById("weight-number");
+    const weightValue = document.getElementById("weight-value");
+
+    weightRange.value = val;
+    weightNumber.value = val;
+    weightValue.innerText = val;
+
+    calculateBMI();
+}
+
+function calculateBMI() {
+    const h = document.getElementById("height-input").value / 100;
+    const w = document.getElementById("weight-input").value;
+
+    if (!h || !w) return;
+
+    const bmi = (w / (h * h)).toFixed(1);
+    document.getElementById("bmi-value").innerText = bmi;
+
+    let category = "Normal";
+    let badge = "bg-success";
+
+    if (bmi < 18.5) {
+        category = "Underweight";
+        badge = "bg-warning";
+    } else if (bmi < 25) {
+        category = "Normal";
+        badge = "bg-success";
+    } else if (bmi < 30) {
+        category = "Overweight";
+        badge = "bg-warning";
+    } else {
+        category = "Obese";
+        badge = "bg-danger";
     }
 
-    // weight updation
-    function updateWeight(val) {
-        document.getElementById("weight-value").innerText = val;
-        calculateBMI();
-    }
-
-    function calculateBMI() {
-        const h = document.getElementById("height-input").value / 100;
-        const w = document.getElementById("weight-input").value;
-
-        if (!h || !w) return;
-
-        const bmi = (w / (h * h)).toFixed(1);
-        document.getElementById("bmi-value").innerText = bmi;
-
-        let category = "Normal";
-        let badge = "bg-success";
-
-        if (bmi < 18.5) {
-            category = "Underweight";
-            badge = "bg-warning";
-        } else if (bmi < 25) {
-            category = "Normal";
-            badge = "bg-success";
-        } else if (bmi < 30) {
-            category = "Overweight";
-            badge = "bg-warning";
-        } else {
-            category = "Obese";
-            badge = "bg-danger";
-        }
-
-        const catEl = document.getElementById("bmi-category");
-        catEl.innerText = category;
-        catEl.className = `badge ${badge}`;
-    }
+    const catEl = document.getElementById("bmi-category");
+    catEl.innerText = category;
+    catEl.className = `badge ${badge}`;
+}
 
     function hideError() {
         document.getElementById('error-container').style.display = 'none';


### PR DESCRIPTION
## 📄 Description

This PR adds direct number input fields for height and weight alongside the existing sliders.

Users can now enter exact height and weight values directly, which improves BMI calculation accuracy and makes the prediction form easier to use.

## 🔗 Related Issues

Fixes #345

## ✨ Changes Summary

- Added direct height input field in `home.html`
- Added direct weight input field in `home.html`
- Added direct height input field in `ml_prediction.html`
- Added direct weight input field in `ml_prediction.html`
- Synced number inputs with existing height and weight sliders
- Preserved BMI calculation and category update behavior

## 📸 Screenshots

After change:

<img width="435" height="199" alt="image" src="https://github.com/user-attachments/assets/80527ce1-9eca-4328-bc86-b7f1d2dc9b5c" />

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Added direct height and weight input support
- [x] Verified BMI updates after changing height and weight values

## 🤖 AI Assistance Disclosure

I used AI assistance to understand the issue requirements, plan the UI update, and structure the PR description. I reviewed and tested the code changes before submission.
