### PR TITLE
feat: add confidence validation for image disease predictions

### DIFF
--- a/backend/routes/predict_disease_type_routes.py
+++ b/backend/routes/predict_disease_type_routes.py
@@ -71,6 +71,8 @@ MODEL_CONFIG = {
 KERAS_MODEL_CACHE = {}
 TFLITE_MODEL_CACHE = {}
 
+# Confidence threshold for eliminating low-confidence predictions (can be adjusted or made dynamic)
+CONFIDENCE_THRESHOLD = 0.60
 
 # loads keras model in the KERAS_MODEL_CACHE (for eye disease prediction)
 def load_keras_model(model_type):
@@ -198,6 +200,22 @@ def predict():
             idx = int(np.argmax(preds))
             confidence = float(preds[idx])
             predicted_class = MODEL_CONFIG[model_type]["class_names"][idx]
+
+
+            print(
+                f"Prediction: {predicted_class}, "
+                f"Confidence: {confidence:.4f}"
+            )
+
+            if confidence < CONFIDENCE_THRESHOLD:
+                return jsonify({
+                    "error": (
+                        f"The uploaded image does not appear to be a valid "
+                        f"{model_type} disease image. "
+                        "Please upload a clear medical image."
+                    ),
+                    "confidence": round(confidence * 100, 2)
+                }), 400
 
             # 4. NEW: Generate Grad-CAM / Score-CAM heatmap
             gradcam_overlay = None


### PR DESCRIPTION
## 📄 Description

This PR adds confidence-based validation for image disease predictions to reduce misleading predictions for unrelated images.

This PR includes:

* [x] Adds confidence threshold validation before returning prediction results
* [x] Fixes low-confidence unrelated images being classified as diseases
* [x] Updates API responses to return a validation message for invalid image inputs

## 🔗 Related Issues

Fixes #398

## Changes Summary

* Added a configurable confidence threshold for image disease predictions
* Added validation handling for low-confidence predictions
* Returns a user-friendly error message instead of a disease prediction when confidence is below the threshold
* Preserved the existing prediction workflow for valid high-confidence predictions

## Screenshots 

### Before
<img width="626" height="813" alt="image" src="https://github.com/user-attachments/assets/fb938505-d179-44d7-8e5e-4595fdaab8f0" />

* Club logo → Disease prediction

### After
<img width="859" height="879" alt="image" src="https://github.com/user-attachments/assets/6d231cf5-d030-460c-a66b-52e507026f91" />

<img width="655" height="798" alt="image" src="https://github.com/user-attachments/assets/a6f7ee2d-e1ee-47ab-bd9a-fe7e15bdb384" />


* AI Club logo → Validation message
* Flowchart image → Validation message
* Table/chart image → Validation message

## ✅ Checklist

* [x] I have performed a self-review of my code
* [x] I have commented code in hard-to-understand areas
* [x] My changes generate no new warnings

## Notes

During testing, confidence-based filtering reduced false predictions from several unrelated images. Some non-medical images may still receive high-confidence predictions from the underlying model. A dedicated image-domain validation step could be considered as a future enhancement.
