### PR TITLE
Add Bayesian order-invariance verification diagnostics and regression…

### DIFF
--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -144,6 +144,14 @@ def predict_disease():
             false_positive_rate=0.05,
         )
 
+        order_invariance_diagnostics = calculator.verify_order_invariance(
+            model=ml_model,
+            disease=disease,
+            symptoms=symptoms,
+            tolerance=1e-6,
+            max_permutations=6,
+        )
+
         # Determine risk level for storage
         risk_assessment = get_risk_level(bayesian_result["posterior"] * 100)
         risk_level_map = {
@@ -268,6 +276,7 @@ def predict_disease():
                 "false_positive_rate": round(
                     bayesian_result["false_positive_rate"] * 100, 2
                 ),
+                "order_invariance": order_invariance_diagnostics,
             },
             "risk_assessment": risk_assessment,
         }

--- a/backend/tests/test_calculator.py
+++ b/backend/tests/test_calculator.py
@@ -1,12 +1,39 @@
 import csv
 import io
+import importlib.util
 import os
 import sys
 import tempfile
 import unittest
 
-from backend.src.calculator import (bayesian_survival, display_results,
-                                    load_data)
+TEST_DIR = os.path.dirname(__file__)
+BACKEND_DIR = os.path.abspath(os.path.join(TEST_DIR, ".."))
+
+
+def _load_module_from_path(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+_src_calculator = _load_module_from_path(
+    "backend_src_calculator",
+    os.path.join(BACKEND_DIR, "src", "calculator.py"),
+)
+_ml_model_module = _load_module_from_path(
+    "backend_models_ml_model",
+    os.path.join(BACKEND_DIR, "models", "ml_model.py"),
+)
+_utils_calculator = _load_module_from_path(
+    "backend_utils_calculator",
+    os.path.join(BACKEND_DIR, "utils", "calculator.py"),
+)
+
+bayesian_survival = _src_calculator.bayesian_survival
+load_data = _src_calculator.load_data
+display_results = _src_calculator.display_results
+DiseaseMLModel = _ml_model_module.DiseaseMLModel
+BayesCalculator = _utils_calculator.BayesCalculator
 
 
 class TestBayesianCalculator(unittest.TestCase):
@@ -122,6 +149,24 @@ class TestBayesianCalculator(unittest.TestCase):
         output = captured.getvalue()
         self.assertIn("Prior: 0.5", output)
         self.assertIn("Specificity: 0.9", output)
+
+    def test_verify_order_invariance_on_symptom_sequences(self):
+        model = DiseaseMLModel()
+        calculator = BayesCalculator()
+        symptoms = ["fever", "cough", "fatigue"]
+
+        diagnostics = calculator.verify_order_invariance(
+            model=model,
+            disease="influenza",
+            symptoms=symptoms,
+            tolerance=1e-8,
+            max_permutations=6,
+        )
+
+        self.assertTrue(diagnostics["order_invariant"])
+        self.assertEqual(diagnostics["tested_orderings"], 6)
+        self.assertAlmostEqual(diagnostics["posterior_drift"], 0.0, places=8)
+        self.assertEqual(len(diagnostics["posterior_values"]), 6)
 
 
 if __name__ == "__main__":

--- a/backend/utils/calculator.py
+++ b/backend/utils/calculator.py
@@ -1,4 +1,5 @@
 import csv
+import itertools
 import math
 
 
@@ -75,6 +76,17 @@ class BayesCalculator:
     def __init__(self):
         pass
 
+    def _compute_posterior_value(
+        self, prior: float, likelihood: float, false_positive_rate: float = 0.05
+    ) -> float:
+        """Compute the raw posterior value without rounding."""
+        complement_prior = 1.0 - prior
+        numerator = likelihood * prior
+        denominator = numerator + (false_positive_rate * complement_prior)
+        if math.isclose(denominator, 0.0):
+            return 0.0
+        return numerator / denominator
+
     def calculate_posterior(
         self, prior: float, likelihood: float, false_positive_rate: float = 0.05
     ) -> dict:
@@ -96,14 +108,7 @@ class BayesCalculator:
             if not (0.0 <= value <= 1.0):
                 raise ValueError(f"{name} must be between 0 and 1. Got {value}")
 
-        complement_prior = 1.0 - prior
-        numerator = likelihood * prior
-        denominator = numerator + (false_positive_rate * complement_prior)
-
-        if math.isclose(denominator, 0.0):
-            posterior = 0.0
-        else:
-            posterior = numerator / denominator
+        posterior = self._compute_posterior_value(prior, likelihood, false_positive_rate)
 
         if posterior < 0.35:
             risk_category = "Low"
@@ -125,6 +130,85 @@ class BayesCalculator:
             "shift_magnitude": round(posterior - prior, 4),
         }
 
+    def verify_order_invariance(
+        self,
+        model,
+        disease: str,
+        symptoms: list,
+        tolerance: float = 1e-6,
+        max_permutations: int = 6,
+    ) -> dict:
+        """Verify Bayesian posterior stability across symptom order permutations."""
+        if symptoms is None:
+            symptoms = []
+
+        ordered_sequences = []
+        seen = set()
+        for perm in itertools.islice(itertools.permutations(symptoms), None):
+            if perm in seen:
+                continue
+            seen.add(perm)
+            ordered_sequences.append(list(perm))
+            if len(ordered_sequences) >= max_permutations:
+                break
+
+        if not ordered_sequences:
+            return {
+                "order_invariant": True,
+                "tested_orderings": 0,
+                "posterior_drift": 0.0,
+                "max_posterior": 0.0,
+                "min_posterior": 0.0,
+                "posterior_values": [],
+                "diagnostic": "No symptoms provided; order invariance holds by definition.",
+            }
+
+        baseline_order = ordered_sequences[0]
+        baseline_prediction = model.predict_disease_probability(disease, baseline_order)
+        baseline_posterior = self._compute_posterior_value(
+            baseline_prediction["prior_probability"],
+            baseline_prediction["likelihood"],
+            0.05,
+        )
+
+        posterior_values = [baseline_posterior]
+        drift_records = []
+        for seq in ordered_sequences[1:]:
+            prediction = model.predict_disease_probability(disease, seq)
+            posterior = self._compute_posterior_value(
+                prediction["prior_probability"],
+                prediction["likelihood"],
+                0.05,
+            )
+            posterior_values.append(posterior)
+            drift_records.append(
+                {
+                    "symptom_order": seq,
+                    "posterior": round(posterior, 8),
+                    "drift": round(abs(posterior - baseline_posterior), 8),
+                }
+            )
+
+        max_posterior = max(posterior_values)
+        min_posterior = min(posterior_values)
+        max_drift = max_posterior - min_posterior
+        invariant = max_drift <= tolerance
+
+        return {
+            "order_invariant": invariant,
+            "tested_orderings": len(ordered_sequences),
+            "posterior_drift": round(max_drift, 8),
+            "max_posterior": round(max_posterior, 8),
+            "min_posterior": round(min_posterior, 8),
+            "posterior_values": [round(p, 8) for p in posterior_values],
+            "diagnostic": (
+                "Posterior probability remained stable across symptom orderings."
+                if invariant
+                else "Detected non-commutative posterior drift across symptom orderings."
+            ),
+            "tolerance": tolerance,
+            "drift_records": drift_records,
+        }
     def calculate_with_test_result(
         self,
         prior: float,


### PR DESCRIPTION
## 📄 Description

A clear and concise description of what this PR does.


- [x] Adds order-invariance verification for Bayesian symptom inference
- [x] Fixes hidden instability by measuring posterior drift across symptom permutations
- [x] Updates ML prediction response with diagnostic metadata

## 🔗 Related Issues

> Fixes #381 

## ✨ Changes Summary

List all the key changes made in this PR:

- Added `BayesCalculator.verify_order_invariance()` in calculator.py
- Integrated order-invariance diagnostics into ml_routes.py
- Added regression coverage in test_calculator.py
- Ensured diagnostics report `order_invariant`, `posterior_drift`, `posterior_values`, `drift_records`, and tolerance metadata

## 📸 Screenshots (if applicable)

No screenshots included.

## ✅ Checklist

Please check all that apply before submitting your pull request:

- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings