### PR TITLE
fix(#414): skip prediction history writes for unauthenticated users

### DIFF
--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -188,29 +188,35 @@ def predict_disease():
                 trend_factor=trend_factor,
             )
 
-            prediction_record = PredictionHistory(
-                user_id=current_user.id if current_user.is_authenticated else None,
-                disease=disease,
-                symptoms=json.dumps(symptoms),
-                patient_age=age,
-                ml_probability=ml_prediction["raw_probability"],
-                bayesian_posterior=bayesian_result["posterior"],
-                confidence_score=confidence_score,
-                survival_probability=survival_prob,
-                heart_rate=cleaned.heart_rate,
-                blood_pressure_systolic=cleaned.blood_pressure_systolic,
-                blood_pressure_diastolic=cleaned.blood_pressure_diastolic,
-                blood_glucose=cleaned.blood_glucose,
-                temperature=cleaned.temperature,
-                risk_level=risk_level_db,
-            )
-            db.session.add(prediction_record)
-            db.session.commit()
-            print(
-                f"✅ Prediction saved: disease={disease}, risk_level={risk_level_db}, survival_prob={survival_prob}%"
-            )
+            # Only persist history for authenticated users.
+            # Storing records with user_id=None leaks sensitive health data
+            # (vitals, diagnoses) with no data subject linkage, making it
+            # impossible to honour deletion requests and causing the table
+            # to grow unboundedly with orphaned rows.
+            if current_user.is_authenticated:
+                prediction_record = PredictionHistory(
+                    user_id=current_user.id,
+                    disease=disease,
+                    symptoms=json.dumps(symptoms),
+                    patient_age=age,
+                    ml_probability=ml_prediction["raw_probability"],
+                    bayesian_posterior=bayesian_result["posterior"],
+                    confidence_score=confidence_score,
+                    survival_probability=survival_prob,
+                    heart_rate=cleaned.heart_rate,
+                    blood_pressure_systolic=cleaned.blood_pressure_systolic,
+                    blood_pressure_diastolic=cleaned.blood_pressure_diastolic,
+                    blood_glucose=cleaned.blood_glucose,
+                    temperature=cleaned.temperature,
+                    risk_level=risk_level_db,
+                )
+                db.session.add(prediction_record)
+                db.session.commit()
+                print(
+                    f"Prediction saved: disease={disease}, risk_level={risk_level_db}, survival_prob={survival_prob}%"
+                )
         except Exception as db_error:
-            print(f"⚠️ Failed to save prediction to database: {db_error}")
+            print(f"Failed to save prediction to database: {db_error}")
             traceback.print_exc()
             db.session.rollback()
 
@@ -271,28 +277,29 @@ def predict_disease():
             "risk_assessment": risk_assessment,
         }
 
-        # Issue #230: also persist via the unified history service so the
-        # new History page (PatientHistory) shows this prediction. The
-        # existing PredictionHistory save above is left untouched.
-        save_history(
-            user_id=current_user.id if current_user.is_authenticated else None,
-            prediction_type="symptom",
-            disease=disease.replace("_", " ").title(),
-            inputs={
-                "symptoms": symptoms,
-                "age": age,
-                "height_cm": height,
-                "weight_kg": weight,
-            },
-            results={
-                "ml_probability": ml_prediction["raw_probability"],
-                "bayesian_posterior": bayesian_result["posterior"],
-                "confidence_score": confidence_score,
-                "survival_probability": survival_prob,
-            },
-            probability=bayesian_result["posterior"],
-            risk_level=risk_level_db,
-        )
+        # Persist via the unified history service so the History page
+        # (PatientHistory) shows this prediction. Only written for
+        # authenticated users to avoid orphaned anonymous health records.
+        if current_user.is_authenticated:
+            save_history(
+                user_id=current_user.id,
+                prediction_type="symptom",
+                disease=disease.replace("_", " ").title(),
+                inputs={
+                    "symptoms": symptoms,
+                    "age": age,
+                    "height_cm": height,
+                    "weight_kg": weight,
+                },
+                results={
+                    "ml_probability": ml_prediction["raw_probability"],
+                    "bayesian_posterior": bayesian_result["posterior"],
+                    "confidence_score": confidence_score,
+                    "survival_probability": survival_prob,
+                },
+                probability=bayesian_result["posterior"],
+                risk_level=risk_level_db,
+            )
 
         return jsonify(result), 200
 
@@ -500,11 +507,11 @@ def predict_multiple_diseases():
          # Issue #230: also persist the top prediction via the unified
         # history service so the PatientHistory-backed History page
         # reflects this differential diagnosis run.
-        if top_predictions:
+        if top_predictions and current_user.is_authenticated:
             top_pred = top_predictions[0]
             top_risk = top_pred.get("risk_level") or {}
             save_history(
-                user_id=current_user.id if current_user.is_authenticated else None,
+                user_id=current_user.id,
                 prediction_type="symptom",
                 disease=top_pred["disease"],
                 inputs={


### PR DESCRIPTION
## Summary

`ml_routes.py` wrote `PredictionHistory` rows and called `save_history()` with `user_id=None` for every anonymous prediction request. These records accumulate in the database indefinitely because there is no cleanup mechanism and no data subject linkage, making GDPR-compliant deletion impossible. They also contain sensitive health data including vitals, symptoms, diagnoses, risk levels, and survival probability estimates.

Closes #414

## Root Cause

Three separate write paths in `predict_disease()` used the pattern:

```python
user_id=current_user.id if current_user.is_authenticated else None
```

This means every anonymous prediction resulted in a row persisted with `user_id=NULL`, containing full health data but no way to identify or delete it.

## Changes

**`backend/routes/ml_routes.py`**

All three write paths are now guarded by `if current_user.is_authenticated:`:

1. **`PredictionHistory` direct insert** (line ~191): wrapped in `if current_user.is_authenticated:`, `user_id` is now always `current_user.id` (never `None`).

2. **First `save_history()` call** (line ~283): wrapped in `if current_user.is_authenticated:`, `user_id` is always `current_user.id`.

3. **Second `save_history()` call for differential diagnosis** (line ~513): condition changed from `if top_predictions:` to `if top_predictions and current_user.is_authenticated:`.

Anonymous users still receive the full prediction result in the API response. Only the database persistence is skipped.

## Impact

- Stops unbounded accumulation of anonymous health records.
- All stored prediction history rows have a valid `user_id`, enabling deletion when a user account is deleted.
- No change to the prediction results returned to any caller.

## How to Test

1. Submit a prediction request without logging in: the response should still contain the full prediction result. Verify no new row with `user_id=NULL` was inserted.
2. Submit a prediction request while logged in: the response should be identical to before, and a row should be inserted with the correct `user_id`.

## Checklist

- [x] All three write paths in `ml_routes.py` are guarded.
- [x] Anonymous callers still receive prediction results.
- [x] No new dependencies or schema changes.