### PR TITLE
fix(#410): add make_user_cache_key helper to prevent cross-user cache leaks

### DIFF
--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -11,6 +11,7 @@ from backend.models.prediction import PredictionHistory
 from backend.preprocessing import PreprocessingError, clean_prediction_payload
 from backend.services.history_service import save_history
 from backend.utils.calculator import BayesCalculator
+from backend.utils.cache_utils import make_user_cache_key  # noqa: F401 — imported so callers can use it with @cache.cached
 from backend.utils.uncertainty_handler import uncertainty_handler  # NEW
 
 ml_bp = Blueprint("ml", __name__)

--- a/backend/utils/cache_utils.py
+++ b/backend/utils/cache_utils.py
@@ -1,0 +1,71 @@
+"""
+Cache key utilities for Flask-Caching.
+
+Flask-Caching's default key_prefix is derived from the request path and
+query string only.  When a view returns personalised data (prediction
+results that incorporate the authenticated user's prior history, survival
+probability, or Bayesian trend factor) caching with that default key
+causes User A's result to be served to User B whenever they submit
+identical inputs during the cached window.
+
+Usage
+-----
+Import ``make_user_cache_key`` and pass it as the ``key_prefix`` argument
+to ``@cache.cached``:
+
+    from backend.utils.cache_utils import make_user_cache_key
+
+    @bp.route("/api/ml/predict", methods=["POST"])
+    @cache.cached(timeout=300, key_prefix=make_user_cache_key)
+    def predict_disease():
+        ...
+
+The returned key includes:
+- The request path
+- A SHA-256 digest of the raw request body (so different payloads get
+  different cache slots)
+- The authenticated user's ID, or the string ``"anonymous"`` for
+  unauthenticated requests
+
+For endpoints that must never serve cached personal data to anonymous
+callers, pair this helper with ``@login_required`` so the ``"anonymous"``
+bucket is never populated.
+"""
+
+import hashlib
+
+from flask import request
+from flask_login import current_user
+
+
+def make_user_cache_key() -> str:
+    """
+    Build a cache key that is unique per (path, request body, user).
+
+    Prevents personalised prediction results from leaking across user
+    sessions when Flask-Caching is enabled on a prediction endpoint.
+
+    Returns
+    -------
+    str
+        A cache key of the form
+        ``view:<path>:body:<body_hash>:user:<user_id>``.
+    """
+    path = request.path
+
+    # Hash the raw body so that different payloads map to different slots.
+    # Using a digest rather than the raw body keeps the key short and safe
+    # to use as a Redis / Memcached key.
+    body = request.get_data()
+    body_hash = hashlib.sha256(body).hexdigest()[:16]
+
+    # Bind the key to the authenticated user so that User A's cached result
+    # is never served to User B.  Anonymous callers get their own isolated
+    # bucket; combine this helper with @login_required on personal endpoints
+    # to prevent that bucket from being populated at all.
+    if current_user and current_user.is_authenticated:
+        user_part = str(current_user.id)
+    else:
+        user_part = "anonymous"
+
+    return f"view:{path}:body:{body_hash}:user:{user_part}"


### PR DESCRIPTION
## Summary

Flask-Caching is initialised in `backend/__init__.py` with `SimpleCache` and an 86 400 s default timeout. The default `key_prefix` for `@cache.cached` is derived from the request path and query string only. If caching is added to any endpoint that returns personalised results (such as `predict_disease()`, which incorporates the authenticated user's prior history, Bayesian trend factor, and survival probability) identical inputs from two different users would share the same cache slot. User A's personalised result would be served verbatim to User B.

Although the `@cache.cached` decorator was removed from `predict_disease()` in a recent refactor, the caching infrastructure remains active and the underlying risk would reappear as soon as caching is re-introduced on any personalised route.

Closes #410

## Root Cause

Flask-Caching's default key does not include a user identity component:

```python
# Default key: view//api/ml/predict
@cache.cached(timeout=300)
def predict_disease():
    ...
```

Two requests with identical JSON bodies from different authenticated users map to the same key, so the first user's personalised result is returned from cache for all subsequent callers with the same inputs.

## Fix

Added `backend/utils/cache_utils.py` containing `make_user_cache_key()`, a drop-in `key_prefix` callable for `@cache.cached` that builds a key from three components:

| Component | Value |
|---|---|
| Path | `request.path` |
| Body hash | 16-char SHA-256 digest of raw request body |
| User identity | `str(current_user.id)` for authenticated users, `"anonymous"` otherwise |

Example key: `view:/api/ml/predict:body:a3f1c9d2e4b7f021:user:42`

**Safe usage:**
```python
from backend.utils.cache_utils import make_user_cache_key

@bp.route("/api/ml/predict", methods=["POST"])
@cache.cached(timeout=300, key_prefix=make_user_cache_key)
def predict_disease():
    ...
```

For endpoints returning personal health data, pair with `@login_required` so the `"anonymous"` bucket is never populated.

`make_user_cache_key` is also imported in `ml_routes.py` so it is visible to developers working on the prediction routes and ready to use without searching for it.

## Files Changed

- `backend/utils/cache_utils.py` (new): `make_user_cache_key()` with full docstring explaining the cross-user leak, the key structure, and the `@login_required` pairing recommendation.
- `backend/routes/ml_routes.py`: imports `make_user_cache_key` to make it discoverable.

## How to Test

```python
from backend.utils.cache_utils import make_user_cache_key
from flask import Flask
from flask_login import UserMixin

app = Flask(__name__)

with app.test_request_context("/api/ml/predict", method="POST", data=b'{"disease":"diabetes"}'):
    # Simulate user 1
    class FakeUser(UserMixin):
        id = 1
        is_authenticated = True

    import flask_login
    flask_login.current_user._get_current_object = lambda: FakeUser()

    key_user1 = make_user_cache_key()
    assert "user:1" in key_user1
    assert "anonymous" not in key_user1
```

## Checklist

- [x] No breaking changes to existing routes.
- [x] No new third-party dependencies (uses only stdlib `hashlib`).
- [x] Module docstring explains the cross-user leak scenario and correct usage.