### PR TITLE
fix: display confidence metrics correctly on main page

### DIFF
--- a/backend/models/ml_model.py
+++ b/backend/models/ml_model.py
@@ -1237,6 +1237,14 @@ class DiseaseMLModel:
 
         raw_probability = self.sigmoid(z)
         calibrated_probability = self.calibrated_sigmoid(z)
+        calibration_gap = abs(
+            raw_probability - calibrated_probability
+        )
+
+        calibration_score = max(
+            0,
+            1 - calibration_gap
+        )
 
         prior = min(0.95, max(0.05, raw_probability))
         likelihood = 0.75 + (raw_probability * 0.20)
@@ -1262,6 +1270,8 @@ class DiseaseMLModel:
             "calibrated_probability": float(calibrated_probability),
             "prior_probability": float(prior),
             "likelihood": float(likelihood),
+            "calibration_gap": float(calibration_gap),
+            "calibration_score": float(calibration_score),
             "symptoms_matched": len(matched_symptoms),
             "total_symptoms": len(symptoms),
             "confidence_score": confidence_score,

--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -384,6 +384,9 @@ def predict_multiple_diseases():
             top_prediction = {
                 "disease": pred["disease"].replace("_", " ").title(),
                 "probability": round(pred["raw_probability"] * 100, 2),
+                "calibrated_probability":round(pred["calibrated_probability"] * 100, 2),
+                "calibration_gap":round(pred["calibration_gap"] * 100, 2),
+                "calibration_score":round(pred["calibration_score"] * 100, 2),
                 "prior": round(bayesian["prior"] * 100, 2),
                 "likelihood": round(bayesian["likelihood"] * 100, 2),
                 "posterior": round(bayesian["posterior"] * 100, 2),


### PR DESCRIPTION
## 📄 Description

This PR is submitted as part of GSSoC 2026.
This PR fixes the confidence metrics displayed in the Prediction Reliability section on the main ML Disease Prediction page.

Previously, calibration-related values were displayed as `undefined%` because the backend did not provide the required fields expected by the frontend.

This PR includes:

- [x] Fixes confidence metric display issue
- [x] Adds calibration metric calculations
- [x] Updates API response with calibration data

## 🔗 Related Issues

Fixes #403

## ✨ Changes Summary

- Added `calibration_gap` calculation based on the difference between raw and calibrated probabilities
- Added `calibration_score` (reliability score) derived from calibration gap
- Exposed calibration metrics through the `/api/ml/predict-multiple` API response
- Fixed Prediction Reliability section values on the main page
- Removed `undefined%` values for:
  - Calibrated Reliability
  - Calibration Gap
  - Reliability Score

## 📸 Screenshots (if applicable)
<img width="979" height="843" alt="image" src="https://github.com/user-attachments/assets/5d610095-0e55-4507-bb50-0fc06a40a4c1" />

<img width="1470" height="854" alt="image" src="https://github.com/user-attachments/assets/6215fb1c-ee65-43c4-b60c-0052660e0e08" />


### Before
- Calibrated Reliability: `undefined%`
- Calibration Gap: `undefined%`
- Reliability Score: `undefined%`

### After
- All confidence and calibration metrics display correctly with valid values

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings

### Implementation Notes

- Calibration Gap is computed as the absolute difference between raw probability and calibrated probability.
- Reliability Score is derived as (1 - Calibration Gap) and expressed as a percentage for UI display.