### PR TITLE
fix: remove stale chatbot stylesheet import

### DIFF
--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -1,6 +1,5 @@
 /* --- Google Font Import --- */
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap');
-@import url('chatbot_style.css');
 
 /* --- CSS Variables for Light/Dark Mode --- */
 :root {


### PR DESCRIPTION
## 📄 Description

This PR removes a stale stylesheet import that referenced a non-existent file (`chatbot_style.css`).

The missing import caused repeated 404 errors in the browser console across multiple pages, even though the chatbot styles are already defined within `chatbot_widget.html`.

This PR includes:

* [x] Fixes repeated 404 errors caused by a missing stylesheet
* [x] Removes unused/stale CSS import
* [x] Improves frontend asset loading consistency

## 🔗 Related Issues

> Fixes #440

## ✨ Changes Summary

* Removed `@import url('chatbot_style.css');` from `backend/static/style.css`
* Eliminated repeated `GET /static/chatbot_style.css 404 (NOT FOUND)` requests
* Verified that chatbot functionality and styling remain unaffected because styles are already defined in `chatbot_widget.html`

## 📸 Screenshots (if applicable)

### Before

* Browser console displayed:
<img width="1905" height="800" alt="image" src="https://github.com/user-attachments/assets/e37c9060-3844-4468-aa16-c43744f77f0b" />

  * `GET /static/chatbot_style.css 404 (NOT FOUND)`

### After
<img width="1600" height="723" alt="image" src="https://github.com/user-attachments/assets/47aa6a2f-c7ec-462e-8e41-89791bb62908" />


* No `chatbot_style.css` requests
* No related console errors
* Chatbot UI continues to function normally

## 🚀 GSSoC 2026

This contribution is submitted as part of **GSSoC 2026**.

## ✅ Checklist

* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings
* [x] The fix has been tested locally
* [x] The issue is reproducible and resolved
