### PR TITLE
fix: move keras/tensorflow imports inside predict_disease to avoid startup crashes (#384)

### DIFF
--- a/backend/models/prediction.py
+++ b/backend/models/prediction.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime
 
 import numpy as np
-from keras.utils import load_img, img_to_array
 from backend import db
 from sqlalchemy import CheckConstraint
 
@@ -17,6 +16,7 @@ CLASS_NAMES = ["Cataract", "Diabetic Retinopathy", "Glaucoma", "Normal"]
 
 def predict_disease(model, img_path, target_size=(224, 224)):
     try:
+        from keras.utils import load_img, img_to_array
         # Load image
         img = load_img(img_path, target_size=target_size)
         img_array = img_to_array(img)


### PR DESCRIPTION
## Description

### 🔗 Linked Issue
Closes #384

### 📋 Summary
Moves the top-level `keras.utils` import statement inside the `predict_disease` utility function in `backend/models/prediction.py`.

### 🔍 Problem / Motivation
In `backend/models/prediction.py`, the import `from keras.utils import load_img, img_to_array` was declared at the top-level of the file. Because this file also defines the `PredictionHistory` database model, this module is imported globally when initializing database setups, middleware, and running non-image tests.

If `tensorflow` or `keras` are not installed in a developer's environment (e.g., standard local development, Python 3.13/3.14 environments where pre-built TensorFlow wheels are not yet available, or light environments that only use the tabular ML/Bayes calculators), the entire application immediately crashes on startup or during test collection with:
```text
ModuleNotFoundError: No module named 'keras'
```

### ✅ Changes Made
- Removed the top-level `from keras.utils import load_img, img_to_array` import.
- Placed it inside the `predict_disease` function block (lazy loading) so it is only loaded when an image prediction is actually requested.

### 🧪 Testing & Verification
- Ran the test suite with a local Python 3.14 setup (which does not have tensorflow/keras installed).
- Verified that all 134 non-image tests (database models, route endpoints, calculations, validation, history logs) collected and passed successfully without any import errors.
- Verified that no changes were made to the core logic, ensuring backwards compatibility.
