### PR TITLE
fix: unify Flask application startup entrypoint (#451)

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -14,10 +14,10 @@ Let's break it down file by file.
 
 ### The Core Logic
 
-#### 📄 `app.py`
-* **WHAT**: This is the main brain of our web application. It's a Python script that uses the Flask framework to run a web server.
-* **WHY**: It acts as the traffic controller. It listens for requests from a user's web browser (like when you click "Calculate") and connects the user interface (the website) with our powerful calculator logic in the backend.
-* **HOW**: When you run `python app.py`, it starts a local web server. It loads the `index.html` file to show you the webpage. When you submit data through the form, this script catches that data, sends it to `calculator.py` for processing, gets the result back, and then reloads the webpage to display the answer.
+#### 📄 `run.py`
+* **WHAT**: This is the application entry point. It's a Python script that uses the Flask framework to start our web server.
+* **WHY**: It serves as the launchpad for the application, initializing the server so it can listen for requests from a user's web browser.
+* **HOW**: When you run `python run.py`, it starts the local web server. The backend routing logic then takes over to load `index.html` and process incoming data.
 
 #### 📁 `src/`
 This folder is where we keep the core, essential logic of our application.
@@ -25,7 +25,7 @@ This folder is where we keep the core, essential logic of our application.
 #### 📄 `src/calculator.py`
 * **WHAT**: A Python script that contains the pure mathematical logic for Bayes' Theorem.
 * **WHY**: By separating the math from the web server code, our project becomes much cleaner and easier to manage. This principle is called **"Separation of Concerns."** It allows us to test our calculator's accuracy without needing to run the whole website.
-* **HOW**: This file likely contains a function that takes numbers as input (like prior probability, sensitivity, etc.), performs the Bayes' Theorem calculation, and returns the final probability. The `app.py` file calls this function whenever it needs to do the math.
+* **HOW**: This file likely contains a function that takes numbers as input (like prior probability, sensitivity, etc.), performs the Bayes' Theorem calculation, and returns the final probability. The `run.py` file (via backend routes) calls this function whenever it needs to do the math.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,11 +1,3 @@
-from dotenv import load_dotenv
-load_dotenv()
-
-from backend import create_app
-
-app = create_app()
-
-
 def _assert_prob(name: str, value: float):
     if not (0.0 <= value <= 1.0):
         raise ValueError(f"{name} must be between 0 and 1 (inclusive). Got {value}.")
@@ -40,5 +32,3 @@ def survival_chance(prior, sensitivity, specificity, test_result):
     return bayes_theorem(prior, sensitivity, specificity, test_result)
 
 
-if __name__ == "__main__":
-    app.run(debug=True)

--- a/backend/tests/test_fetch_endpoints.py
+++ b/backend/tests/test_fetch_endpoints.py
@@ -7,7 +7,7 @@ import json
 
 import pytest
 
-from app import app
+from run import app
 from backend import db
 
 

--- a/setup.md
+++ b/setup.md
@@ -104,13 +104,7 @@ pip install flask numpy pandas scikit-learn matplotlib seaborn
 Run the main application file using one of the following commands:
 
 ```bash
-python app.py
-```
-
-or
-
-```bash
-python main.py
+python run.py
 ```
 
 If the project uses Flask CLI, run:
@@ -126,7 +120,7 @@ flask run
 After starting the application, open your browser and visit:
 
 ```
-http://127.0.0.1:5000/
+http://127.0.0.1:5001/
 ```
 
 You should now see the Disease Prediction web application running locally.
@@ -146,7 +140,7 @@ pip install -r requirements.txt
 
 ### Port Already in Use
 
-- Stop any other service using port 5000
+- Stop any other service using port 5001
 - Or change the port number in the Flask app
 
 ### Virtual Environment Activation Issues (Windows)


### PR DESCRIPTION
## 📄 Description

This PR resolves the duplicate Flask application initialization issue by standardizing `run.py` as the single canonical startup entrypoint.

This PR includes:

- [x] Fixes duplicate Flask application initialization
- [x] Updates test imports to use the canonical application entrypoint
- [x] Updates documentation to consistently reference `run.py`

## 🔗 Related Issues

> Fixes #451

## ✨ Changes Summary

- Removed duplicate Flask application initialization logic from `app.py`
- Preserved existing probability calculation utilities (`bayes_theorem`, `survival_chance`) in `app.py`
- Updated `backend/tests/test_fetch_endpoints.py` to import the Flask application from `run.py`
- Updated `setup.md` to use `python run.py` as the recommended startup command
- Corrected documentation references to the application port
- Updated `PROJECT_STRUCTURE.md` to accurately describe `run.py` as the application entrypoint
- Consolidated the project startup flow around a single Flask entrypoint

## 📸 Screenshots (if applicable)

N/A – No UI changes were made.

## ✅ Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings