### PR TITLE
fix(security): read FLASK_DEBUG from environment instead of hardcoding debug=True

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,4 +41,6 @@ def survival_chance(prior, sensitivity, specificity, test_result):
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    import os
+    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(debug=debug)


### PR DESCRIPTION
## Description

`app.py` called `app.run(debug=True)` unconditionally. This enabled the Werkzeug interactive debugger for every direct invocation. The debugger exposes a PIN-protected remote code execution console at `/__debugger__` and causes full stack traces with internal file paths to be included in HTTP error responses, both of which are unacceptable outside a tightly controlled local environment.

## Root Cause

```python
if __name__ == "__main__":
    app.run(debug=True)  # debug always on
```

## Related Issue

Closes #411

## Type of Change

- [x] Bug fix (security)

## Changes Made

- `app.py`:
  - Read debug mode from the `FLASK_DEBUG` environment variable (defaults to `false`).
  - The server now starts in safe mode unless a developer explicitly sets `FLASK_DEBUG=true` in their local environment.

## Testing Done

1. Run `python app.py` without setting `FLASK_DEBUG`: server starts with `debug=False`, no Werkzeug debugger.
2. Run `FLASK_DEBUG=true python app.py`: server starts with `debug=True` for local development.
3. Existing routes and functionality unchanged.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue