### PR TITLE
Fix: apply @rate_limit decorator to auth, ml, chat, and predict routes

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import OperationalError
 
 from backend import bcrypt, db
 from backend.models.user import User
+from backend.middleware import rate_limit
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -149,6 +150,7 @@ def auth():
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
+@rate_limit("default")
 def login():
     if current_user.is_authenticated:
         return redirect(url_for("auth.profile"))
@@ -180,6 +182,7 @@ MIN_PASSWORD_LEN = 8
 MAX_USERNAME_LEN = 20  
 
 @auth_bp.route('/signup', methods=['POST'])
+@rate_limit("default")
 def signup():
     username = (request.form.get('username') or '').strip()
     email    = (request.form.get('email')    or '').strip()

--- a/backend/routes/chat_routes.py
+++ b/backend/routes/chat_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+from backend.middleware import rate_limit
 
 from backend.utils.gemini_helper import generate_chat_response
 
@@ -6,6 +7,7 @@ chat_bp = Blueprint("chat", __name__)
 
 
 @chat_bp.route("/api/chat", methods=["POST"])
+@rate_limit("default")
 def chat():
     """
     API endpoint to handle chatbot messages.

--- a/backend/routes/ml_routes.py
+++ b/backend/routes/ml_routes.py
@@ -13,6 +13,7 @@ from backend.services.history_service import save_history
 from backend.utils.calculator import BayesCalculator
 from backend.utils.cache_utils import make_user_cache_key  # noqa: F401 — imported so callers can use it with @cache.cached
 from backend.utils.uncertainty_handler import uncertainty_handler  # NEW
+from backend.middleware import rate_limit
 
 ml_bp = Blueprint("ml", __name__)
 
@@ -40,6 +41,7 @@ def ml_prediction_page():
 
 
 @ml_bp.route("/api/ml/predict", methods=["POST"])
+@rate_limit("prediction")
 def predict_disease():
     """
     API endpoint for ML disease prediction.
@@ -311,6 +313,7 @@ def predict_disease():
 
 
 @ml_bp.route("/api/ml/predict-multiple", methods=["POST"])
+@rate_limit("ml_analysis")
 def predict_multiple_diseases():
     """
     API endpoint for differential diagnosis (predict multiple diseases).

--- a/backend/routes/predict_disease_type_routes.py
+++ b/backend/routes/predict_disease_type_routes.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 from flask import Blueprint, jsonify, request
 from flask_login import current_user, login_required
 from PIL import Image
+from backend.middleware import rate_limit
 
 from backend.services.history_service import save_history
 from backend.utils.gradcam import generate_gradcam_overlay  # NEW
@@ -175,6 +176,7 @@ def _validate_image_magic(stream) -> bool:
 
 #  Main prediction route
 @predict_disease_type_bp.route("/predict", methods=["POST"])
+@rate_limit("prediction")
 @login_required
 def predict():
     # Accept file as "image" or "file"


### PR DESCRIPTION
## 📄 Description
This PR fixes the `@rate_limit` decorator not being applied to any route despite the middleware already existing in `backend/middleware/security.py`.

This PR includes:
- [x] Fixes missing `@rate_limit` decorator on auth, ML prediction, disease type prediction, and chat routes
- [x] Adds `from backend.middleware import rate_limit` import to all 4 affected route files

## 🔗 Related Issues
Fixes #423

## ✨ Changes Summary
- Added `@rate_limit("default")` to `/login` and `/signup` in `auth_routes.py`
- Added `@rate_limit("prediction")` to `/api/ml/predict` in `ml_routes.py`
- Added `@rate_limit("ml_analysis")` to `/api/ml/predict-multiple` in `ml_routes.py`
- Added `@rate_limit("prediction")` above `@login_required` to `/predict` in `predict_disease_type_routes.py`
- Added `@rate_limit("default")` to `/api/chat` in `chat_routes.py`

## 📸 Screenshots (if applicable)
**Rate limiting verified on `/api/ml/predict-multiple` (ml_analysis: 20 req/min):**
```
Request 1–20:  400  (endpoint reached, rate limit not yet hit)
Request 21–35: 429  (rate limit enforced correctly)
```

## ✅ Checklist
- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings