### PR TITLE
fix: validate confidence_score and top2_score range in evaluate() (#453)

### DIFF
--- a/backend/utils/uncertainty_handler.py
+++ b/backend/utils/uncertainty_handler.py
@@ -89,6 +89,16 @@ class UncertaintyHandler:
             reason         str|None Human-readable explanation when False.
             confidence     float    The raw score that was evaluated.
         """
+        # ── Input validation ─────────────────────────────────────────────────
+        if not (0.0 <= confidence_score <= 1.0):
+            raise ValueError(
+                f"confidence_score must be in [0.0, 1.0], got {confidence_score}"
+            )
+        if top2_score is not None and not (0.0 <= top2_score <= 1.0):
+            raise ValueError(
+                f"top2_score must be in [0.0, 1.0], got {top2_score}"
+            )
+        
         # Check 1 — absolute confidence
         if confidence_score < self.confidence_threshold:
             return {


### PR DESCRIPTION
## 📄 Description

This PR adds input validation to `UncertaintyHandler.evaluate()` to prevent 
out-of-range confidence scores from silently producing misleading prediction results.

This PR includes:
- [x] Fixes missing input validation in `UncertaintyHandler.evaluate()`
- [x] Raises `ValueError` for `confidence_score` or `top2_score` outside `[0.0, 1.0]`

## 🔗 Related Issues

> Fixes #453

## ✨ Changes Summary

- Added input validation at the start of `evaluate()` in `backend/utils/uncertainty_handler.py`
- Raises `ValueError` if `confidence_score` is outside `[0.0, 1.0]`
- Raises `ValueError` if `top2_score` is provided and outside `[0.0, 1.0]`
- Follows the same validation pattern already used in `__init__()`
- All existing behaviour for valid inputs is unchanged

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings
