### PR TITLE
fix: raise ValueError when load_data() would save empty CSV after cle…

### DIFF
--- a/backend/src/calculator.py
+++ b/backend/src/calculator.py
@@ -203,6 +203,8 @@ def load_data(filepath, strict=False, save_results_flag=False, save_path=None):
     if save_results_flag:
         if save_path is None:
             raise ValueError("save_path must be provided if save_results_flag=True")
+        if df.empty:
+            raise ValueError("No valid rows to save after data cleaning.")
         save_results(df, save_path)
 
     return df.to_dict(orient="records")


### PR DESCRIPTION
…aning (#452)

## 📄 Description

This PR fixes an issue in load_data() where an empty CSV file could be silently created when all rows in the input data were removed during cleaning and save_results_flag=True.

This PR includes:

-[x] Adds validation to check for an empty DataFrame before saving results
-[x] Fixes silent creation of empty output CSV files

## 🔗 Related Issues

> Fixes #452

## ✨ Changes Summary

-Added an df.empty check in load_data()
-Raised ValueError("No valid rows to save after data cleaning.") when no valid rows remain and saving is requested
-Prevented creation of misleading CSV files containing only headers
-Preserved existing behavior for valid input datasets

## ✅ Checklist

Please check all that apply before submitting your pull request:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
