### PR TITLE
feat: add fuzzy matching for symptom autocomplete search

### DIFF
--- a/backend/routes/autocomplete_routes.py
+++ b/backend/routes/autocomplete_routes.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, request, jsonify
+from rapidfuzz import fuzz
+from backend.models.ml_model import ml_model
+
+autocomplete_bp = Blueprint("autocomplete", __name__)
+
+@autocomplete_bp.route("/api/symptoms/search", methods=["GET"])
+def search_symptoms():
+    """Fuzzy search for symptoms with ranking."""
+    query = request.args.get("q", "").strip().lower()
+    limit = min(int(request.args.get("limit", 8)), 50)
+    
+    if len(query) < 2:
+        return jsonify([])
+    
+    all_symptoms = ml_model.get_all_unique_symptoms()
+    matches = []
+    for symptom in all_symptoms:
+        label = symptom.get("label", symptom.get("key", "")).lower()
+        score = fuzz.token_set_ratio(query, label)
+        if score > 40:
+            matches.append({
+                "id": symptom.get("key"),
+                "label": symptom.get("label", symptom.get("key")),
+                "score": score
+            })
+    
+    ranked = sorted(matches, key=lambda x: -x["score"])[:limit]
+    return jsonify(ranked)
+


### PR DESCRIPTION
## Summary
Adds autocomplete with fuzzy matching for better UX when searching symptoms. Users can find symptoms even with typos or partial matches.

## Implementation
- GET /api/symptoms/search?q=breath&limit=8 endpoint
- rapidfuzz token_set_ratio for fuzzy matching (handles typos)
- Returns ranked [{id, label, score}] results
- Minimum 2 characters, debounced on frontend

## Example
User types 'feve' → suggests 'fever' at top

## Suggested Labels
- feature - New functionality
- ux - User experience
- search - Search feature
- **GsSOC:approved** - GSSoC 2026 contribution

Thanks for reviewing!