### PR TITLE
docs: remove redundant text in deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,6 @@ python run.py
 
 The application can be deployed to Google Cloud Run.
 
-See:
-docs/deployment/gcp-cloud-run.md
-
 See [docs/deployment/gcp-cloud-run.md](docs/deployment/gcp-cloud-run.md) for deployment instructions.
 
 ---


### PR DESCRIPTION
## 📄 Description

This PR cleans up the "Deployment" section of the README by removing redundant, unformatted text. Previously, the instructions for Google Cloud Run deployment contained an unformatted file path right above the properly formatted markdown link, creating visual clutter and looking like an accidental copy-paste error. This fix ensures only the clean, correct, and clickable markdown link remains.

This PR includes:

- [ ] Adds ...
- [x] Fixes a formatting oversight in the README
- [x] Updates the Deployment section for better readability

## 🔗 Related Issues

> Fixes #none (just a documentation fix)

## ✨ Changes Summary

- Removed redundant plain-text lines (`See:\ndocs/deployment/gcp-cloud-run.md`) from the Deployment section.
- Ensured only the clean, properly formatted, and clickable markdown link remains for the deployment instructions.

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

Please check all that apply before submitting your pull request:

- [x] I have performed a self-review of my code
- [ ] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings