### PR TITLE
[SECURITY] Add rate limiting to Gemini API endpoints to prevent quota exhaustion

### DIFF
--- a/backend/middleware/security.py
+++ b/backend/middleware/security.py
@@ -282,6 +282,7 @@ class RateLimiter:
             "prediction": {"requests": 30, "window": 60},  # 30 req/min
             "ml_analysis": {"requests": 20, "window": 60},  # 20 req/min
             "report": {"requests": 10, "window": 60},  # 10 req/min
+            "gemini": {"requests": 5, "window": 3600},  # 5 req/hour for Gemini API
         }
 
         # Pluggable backend selection

--- a/backend/routes/chat_routes.py
+++ b/backend/routes/chat_routes.py
@@ -7,7 +7,7 @@ chat_bp = Blueprint("chat", __name__)
 
 
 @chat_bp.route("/api/chat", methods=["POST"])
-@rate_limit("default")
+@rate_limit("gemini")
 def chat():
     """
     API endpoint to handle chatbot messages.

--- a/backend/routes/disease_routes.py
+++ b/backend/routes/disease_routes.py
@@ -192,6 +192,7 @@ def contact():
 
 
 @disease_bp.route("/gemini-recommendations", methods=["POST"])
+@rate_limit("gemini")
 def gemini_recommendations():
     data = request.json
     try:


### PR DESCRIPTION
## Summary
Implements per-user rate limiting on Gemini API endpoints to prevent accidental or malicious quota exhaustion and protect shared API resources.

## Problem
The Gemini API endpoints had no rate limiting. A single user could:
- Submit unlimited requests, exhausting monthly Gemini API quota
- Cause service unavailability for all other users
- Incur unexpected API bills exceeding budget
- Launch distributed denial-of-service attacks against API quota

Without rate limiting, one malfunctioning client or malicious actor could exhaust the entire monthly quota.

## Solution
Implemented rate limiting using existing application infrastructure:

### 1. New Rate Limit Configuration
- Added `"gemini"` endpoint type with 5 requests per hour
- Per-user tracking using IP + authentication token hash
- Applies to both Gemini API calls and chat endpoints

### 2. Applied to Gemini Endpoints
- `/gemini-recommendations`: AI-powered disease recommendations
- `/api/chat`: Chatbot using Gemini API
- Both limited to 5 requests/hour per user

### 3. Rate Limit Behavior
- Allows 5 Gemini API calls per hour per user
- Returns HTTP 429 Too Many Requests when exceeded
- Includes Retry-After header with time until reset
- Per-user tracking even behind NAT/proxy

### 4. Error Response
- Clear message indicating rate limit exceeded
- Provides retry-after time
- Graceful failure, not silent

## Changes Made
- Added `"gemini"` configuration to `_limits` dict in security.py
- Applied `@rate_limit("gemini")` to `/gemini-recommendations` route
- Applied `@rate_limit("gemini")` to `/api/chat` route (was "default")

## Testing
- User making 5 requests: All succeed
- User making 6th request within 1 hour: Returns 429 Retry-After
- After 1 hour window: New requests succeed
- Different users: Independent rate limit counters
- Authenticated users: Per-user limits (not just per-IP)

## Performance Impact
- Minimal overhead: Hash-based lookup in rate limit backend
- Existing infrastructure: Uses established rate limiter
- No new external dependencies

## Security & Business Impact
- Prevents quota exhaustion from single malicious user
- Protects shared Gemini API budget
- Ensures fair resource allocation among users
- Prevents surprise API billing
- Foundation for subscription tiers (premium users could have higher limits)

## Configuration
Default: 5 requests per 3600 seconds (1 hour)
Customizable via:
- Database: Update `_limits` dict for future dynamic configuration
- Environment: Could be extended for env var override

## Future Enhancement
- Dynamic rate limits based on user tier (free/premium/enterprise)
- Separate limits for different Gemini models
- Cost-based limits (requests weighted by model cost)
- Analytics dashboard showing API usage

Closes #548