### PR TITLE
feat(theme): implement persistent dark mode theme preference

### DIFF
--- a/backend/models/ml_model.py
+++ b/backend/models/ml_model.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 from typing import Dict, List
 

--- a/backend/static/script.js
+++ b/backend/static/script.js
@@ -16,41 +16,8 @@ const STORAGE_KEY = "calculator_last_state";
 let contentGenerated = false;
 
 // ============================================
-// Dark Mode Toggle Functionality
+// Dark Mode Toggle Functionality (Removed - handled globally in base.html)
 // ============================================
-
-function initDarkMode() {
-  const darkModeToggle = document.getElementById('darkModeToggle');
-  const body = document.body;
-  const sunIcon = document.querySelector('.sun-icon');
-  const moonIcon = document.querySelector('.moon-icon');
-
-  const isDarkMode = localStorage.getItem('darkMode') === 'enabled';
-
-  if (isDarkMode) {
-    body.classList.add('dark-mode');
-    if (sunIcon) sunIcon.style.display = 'block';
-    if (moonIcon) moonIcon.style.display = 'none';
-  }
-
-  if (darkModeToggle) {
-    darkModeToggle.addEventListener('click', () => {
-      body.classList.toggle('dark-mode');
-      const isDark = body.classList.contains('dark-mode');
-      if (sunIcon && moonIcon) {
-        sunIcon.style.display = isDark ? 'block' : 'none';
-        moonIcon.style.display = isDark ? 'none' : 'block';
-      }
-      localStorage.setItem('darkMode', isDark ? 'enabled' : 'disabled');
-    });
-  }
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initDarkMode);
-} else {
-  initDarkMode();
-}
 
 // ============================================
 // Dashboard Menu Functionality

--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -129,6 +129,20 @@ body {
     transform: scale(1.1);
 }
 
+/* --- Dark Mode Icon Styles --- */
+.dark-mode-toggle .sun-icon {
+    display: none;
+}
+.dark-mode-toggle .moon-icon {
+    display: block;
+}
+body.dark-mode .dark-mode-toggle .sun-icon {
+    display: block;
+}
+body.dark-mode .dark-mode-toggle .moon-icon {
+    display: none;
+}
+
 /* --- Card Styling & Hover Effects --- */
 .card {
     background-color: var(--card-bg) !important;

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -284,6 +284,18 @@
 </head>
 
 <body class="d-flex flex-column min-vh-100">
+    <script>
+        (function () {
+            const savedTheme = localStorage.getItem('theme') || localStorage.getItem('darkMode');
+            if (savedTheme === 'dark' || savedTheme === 'enabled') {
+                document.body.classList.add('dark-mode');
+            } else if (savedTheme === 'light' || savedTheme === 'disabled') {
+                document.body.classList.remove('dark-mode');
+            } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                document.body.classList.add('dark-mode');
+            }
+        })();
+    </script>
     <nav class="navbar navbar-expand-lg navbar-dark bg-custom-dark shadow-sm">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" href="/">
@@ -338,7 +350,7 @@
                         <button class="dark-mode-toggle" id="darkModeToggle" aria-label="Toggle dark mode">
                             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                                stroke-linejoin="round" class="sun-icon" style="display: none;">
+                                stroke-linejoin="round" class="sun-icon">
                                 <circle cx="12" cy="12" r="5"></circle>
                                 <line x1="12" y1="1" x2="12" y2="3"></line>
                                 <line x1="12" y1="21" x2="12" y2="23"></line>
@@ -453,37 +465,24 @@
         document.addEventListener("DOMContentLoaded", function () {
             // --- DARK MODE LOGIC ---
             const darkModeToggle = document.getElementById('darkModeToggle');
-            const sunIcon = document.querySelector('.sun-icon');
-            const moonIcon = document.querySelector('.moon-icon');
             const body = document.body;
 
-            // Function to apply theme
-            const applyTheme = (isDark) => {
-                if (isDark) {
-                    body.classList.add('dark-mode');
-                    sunIcon.style.display = 'block';
-                    moonIcon.style.display = 'none';
-                } else {
-                    body.classList.remove('dark-mode');
-                    sunIcon.style.display = 'none';
-                    moonIcon.style.display = 'block';
-                }
-            };
+            if (darkModeToggle) {
+                darkModeToggle.addEventListener('click', function () {
+                    const isCurrentlyDark = body.classList.contains('dark-mode');
+                    const newThemeIsDark = !isCurrentlyDark;
 
-            // Check for saved preference
-            const savedTheme = localStorage.getItem('theme');
-            if (savedTheme === 'dark') {
-                applyTheme(true);
+                    if (newThemeIsDark) {
+                        body.classList.add('dark-mode');
+                        localStorage.setItem('theme', 'dark');
+                        localStorage.setItem('darkMode', 'enabled');
+                    } else {
+                        body.classList.remove('dark-mode');
+                        localStorage.setItem('theme', 'light');
+                        localStorage.setItem('darkMode', 'disabled');
+                    }
+                });
             }
-
-            // Toggle click listener
-            darkModeToggle.addEventListener('click', function () {
-                const isCurrentlyDark = body.classList.contains('dark-mode');
-                const newThemeIsDark = !isCurrentlyDark;
-
-                applyTheme(newThemeIsDark);
-                localStorage.setItem('theme', newThemeIsDark ? 'dark' : 'light');
-            });
 
 
             // --- DASHBOARD DROPDOWN LOGIC ---

--- a/backend/templates/calculator.html
+++ b/backend/templates/calculator.html
@@ -275,29 +275,6 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="{{ url_for('static', filename='script.js') }}"></script>
 
-<script>
-document.addEventListener("DOMContentLoaded", function () {
-const darkModeToggle = document.getElementById('darkModeToggle');
-const menuToggle = document.getElementById('dashboardMenuToggle');
-const dropdown = document.getElementById('dashboardDropdown');
 
-if (darkModeToggle) {
-    darkModeToggle.onclick = function () {
-    document.body.classList.toggle('dark-mode');
-    };
-}
-if (menuToggle && dropdown) {
-    menuToggle.onclick = function (e) {
-    e.stopPropagation();
-    dropdown.classList.toggle('show');
-    };
-    document.addEventListener('click', function (e) {
-    if (!menuToggle.contains(e.target) && !dropdown.contains(e.target)) {
-        dropdown.classList.remove('show');
-    }
-    });
-}
-});
-</script>
 
 {% endblock %}

--- a/backend/utils/uncertainty_handler.py
+++ b/backend/utils/uncertainty_handler.py
@@ -18,6 +18,7 @@ Usage:
         return jsonify(check), 200
 """
 
+from __future__ import annotations
 import os
 
 # ── Configurable thresholds ──────────────────────────────────────────────────


### PR DESCRIPTION
# Description

This PR implements persistent dark mode theme preference using `localStorage` and automatically restores it on startup. It also resolves visual flashing (theme flickering) on page load and cleans up conflicting toggle scripts across the app.

## Closed Issue #485

## Benefits
- Improved user experience and accessibility consistency.
- Zero layout/theme flashing on startup.
- Clean code layout by delegating icon displays entirely to CSS.

## Proposed Changes

### Frontend Styles & HTML Templates
- **`backend/static/style.css`**: Added styling rules to show/hide `.sun-icon` and `.moon-icon` based on the presence of the `dark-mode` class on the `<body>` element.
- **`backend/templates/base.html`**:
  - Inserted a synchronous inline script right after the `<body>` tag to immediately load preference from local storage and prevent any initial theme flash.
  - Removed inline `style="display: none;"` from the `.sun-icon` SVG element to let CSS rules handle visibility.
  - Simplified the click listener to keep both `'theme'` and legacy `'darkMode'` storage keys synchronized.

### Scripts Cleanup
- **`backend/static/script.js`**: Removed the redundant global `initDarkMode` function to prevent double-toggle conflicts.
- **`backend/templates/calculator.html`**: Removed the duplicate inline script block containing conflicting dark mode and menu toggle overrides.

### Python Type Hints Compatibility
- **`backend/models/ml_model.py` & `backend/utils/uncertainty_handler.py`**: Added `from __future__ import annotations` to support Python 3.9 type hint union (`|`) syntax during parsing.

---

## Verification & Testing
  - Default loads in **light mode**.
  - Toggle triggers **dark mode** (correct theme/icon updates).
  - Page reload **maintains dark mode** state.
  - Toggle back switches back to **light mode**.
  - Page reload **maintains light mode** state.

