### PR TITLE
Feature/csv export bmi

### DIFF
--- a/backend/routes/history_routes.py
+++ b/backend/routes/history_routes.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 import logging
 from typing import Optional
 
@@ -222,6 +223,7 @@ def export_history_csv():
             "Disease",
             "Probability (%)",
             "Risk Level",
+            "BMI",
             "Inputs",
             "Results",
             "Notes",
@@ -230,6 +232,15 @@ def export_history_csv():
     )
 
     for entry in entries:
+        bmi = ""
+        if entry.results_json:
+            try:
+                # Handle cases where results_json is already a dict, or parse it if it's a string
+                results_dict = json.loads(entry.results_json) if isinstance(entry.results_json, str) else entry.results_json
+                bmi = results_dict.get("bmi", results_dict.get("BMI", ""))
+            except Exception:
+                pass
+
         writer.writerow(
             [
                 entry.id,
@@ -241,6 +252,7 @@ def export_history_csv():
                     else ""
                 ),
                 entry.risk_level or "",
+                bmi,
                 entry.inputs_json or "",
                 entry.results_json or "",
                 _sanitize_csv_field(entry.notes),

--- a/backend/routes/history_routes.py
+++ b/backend/routes/history_routes.py
@@ -241,6 +241,18 @@ def export_history_csv():
             except Exception:
                 pass
 
+        # Fallback: compute from height/weight in inputs_json if not found in results
+        if bmi == "" and entry.inputs_json:
+            try:
+                inputs_dict = json.loads(entry.inputs_json) if isinstance(entry.inputs_json, str) else entry.inputs_json
+                height_cm = inputs_dict.get("height_cm")
+                weight_kg = inputs_dict.get("weight_kg")
+                if height_cm and weight_kg:
+                    height_m = float(height_cm) / 100
+                    bmi = round(float(weight_kg) / (height_m ** 2), 2)
+            except Exception:
+                pass
+
         writer.writerow(
             [
                 entry.id,

--- a/backend/static/css/history.css
+++ b/backend/static/css/history.css
@@ -47,6 +47,12 @@
   height: 2.25rem;
 }
 
+.history-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .history-actions select {
   padding: 0 0.6rem;
   border: 1px solid var(--color-border, #d1d5db);
@@ -303,20 +309,18 @@
 }
 
 /* --- Dark mode support (project already supports it per README) --- */
-@media (prefers-color-scheme: dark) {
-  .history-container {
-    --color-fg: #e6e9ef;
-    --color-bg: #15181d;
-    --color-muted: #94a1b2;
-    --color-border: #2a2f38;
-    --color-card-bg: #1c2129;
-    --color-pill-bg: #232a35;
-    --color-skeleton-1: #1c2129;
-    --color-skeleton-2: #2a2f38;
-    --color-code-bg: #232a35;
-    --color-info-bg: #1e3a5f;
-    --color-info-fg: #bfdbfe;
-    --color-error-bg: #4b1d1d;
-    --color-error-fg: #fecaca;
-  }
+body.dark-mode .history-container {
+  --color-fg: #e6e9ef;
+  --color-bg: #15181d;
+  --color-muted: #94a1b2;
+  --color-border: #2a2f38;
+  --color-card-bg: #1c2129;
+  --color-pill-bg: #232a35;
+  --color-skeleton-1: #1c2129;
+  --color-skeleton-2: #2a2f38;
+  --color-code-bg: #232a35;
+  --color-info-bg: #1e3a5f;
+  --color-info-fg: #bfdbfe;
+  --color-error-bg: #4b1d1d;
+  --color-error-fg: #fecaca;
 }

--- a/backend/static/css/history.css
+++ b/backend/static/css/history.css
@@ -182,9 +182,6 @@
   font-size: 1rem;
 }
 
-.history-card-risk.risk-low    .value { color: var(--color-success, #15803d); }
-.history-card-risk.risk-medium .value { color: var(--color-warning, #b45309); }
-.history-card-risk.risk-high   .value { color: var(--color-danger,  #b91c1c); }
 
 .history-card-actions {
   display: flex;

--- a/backend/static/js/history.js
+++ b/backend/static/js/history.js
@@ -107,10 +107,11 @@
       ? entry.probability_percent.toFixed(2) + "%"
       : "—";
 
-    const risk = entry.risk_level || "—";
-    const riskClass = risk === "high"   ? "risk-high"
-                    : risk === "medium" ? "risk-medium"
-                    : risk === "low"    ? "risk-low"
+    const risk = (entry.risk_level || "—").toLowerCase();
+    const riskClass = risk === "critical" ? "risk-very-high"
+                    : risk === "high"     ? "risk-high"
+                    : risk === "medium"   ? "risk-medium"
+                    : risk === "low"      ? "risk-low"
                     : "";
 
     const typeLabel = TYPE_LABELS[entry.prediction_type]
@@ -136,9 +137,9 @@
             <span class="label">Probability</span>
             <span class="value">${escapeHTML(probPct)}</span>
           </div>
-          <div class="history-card-risk ${riskClass}">
+          <div class="history-card-risk">
             <span class="label">Risk</span>
-            <span class="value">${escapeHTML(risk)}</span>
+            <span class="value badge rounded-pill ${riskClass}">${escapeHTML(risk)}</span>
           </div>
         </div>
 

--- a/backend/templates/history.html
+++ b/backend/templates/history.html
@@ -23,6 +23,9 @@
         <option value="eyes">Eye disease (image)</option>
         <option value="skin">Skin disease (image)</option>
       </select>
+      <a href="/history/export/csv" class="btn btn-primary">
+          <i class="fas fa-file-csv me-2"></i>Export CSV
+      </a>
       <button id="history-refresh-btn"
               type="button"
               class="btn btn-secondary"

--- a/backend/templates/history.html
+++ b/backend/templates/history.html
@@ -23,7 +23,7 @@
         <option value="eyes">Eye disease (image)</option>
         <option value="skin">Skin disease (image)</option>
       </select>
-      <a href="/history/export/csv" class="btn btn-primary">
+      <a href="/history/export/csv" class="btn btn-outline-primary">
           <i class="fas fa-file-csv me-2"></i>Export CSV
       </a>
       <button id="history-refresh-btn"


### PR DESCRIPTION
## 📄 Description

Completes issue #483.

The project already had a backend CSV export route, but it was not accessible from the Prediction History page and did not include BMI in the exported data. This PR exposes the feature through the UI, extends the export with BMI support, and fixes a few related issues discovered during testing.

This PR includes:

- [x] Adds an **Export CSV** button to the Prediction History page
- [x] Adds a **BMI** column to exported CSV files
- [x] Fixes History page dark mode styling
- [x] Fixes missing badge styling for **critical** risk levels

---

## 🔗 Related Issues

Fixes #483

---

## ✨ Changes Summary

- Added an **Export CSV** button that uses the existing `/history/export/csv` endpoint.
- Extended CSV export to include a **BMI** column. BMI is read from `results_json` when available, otherwise calculated from `height_cm` and `weight_kg` stored in `inputs_json`.
- Updated History page dark mode styling to follow the application's theme (`body.dark-mode`) instead of the operating system preference.
- Fixed missing badge styling for **critical** risk levels.
- Made risk-level matching case-insensitive to avoid future formatting issues.

---

## 📸 Screenshots

### Exported CSV
<img width="1415" height="162" alt="Exported CSV" src="https://github.com/user-attachments/assets/f6979356-0e22-4ce0-a0a4-b3bd9fc55939" />

### History Page (Light Mode)
<img width="1128" height="413" alt="Light Mode" src="https://github.com/user-attachments/assets/cd3931bd-2874-4587-a24c-7512a51ebbb8" />

### History Page (Dark Mode)
<img width="1136" height="401" alt="Dark Mode" src="https://github.com/user-attachments/assets/dc4ddca8-f8ff-4464-a8dd-eee363e83a98" />

---

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas
- [x] My changes generate no new warnings