### PR TITLE
Fix image prediction flow and improve low-confidence handling

### DIFF
--- a/backend/routes/predict_disease_type_routes.py
+++ b/backend/routes/predict_disease_type_routes.py
@@ -14,6 +14,10 @@ from backend.services.history_service import save_history
 from backend.utils.gradcam import generate_gradcam_overlay  # NEW
 from backend.utils.gradcam import generate_tflite_scorecam_overlay
 
+from functools import wraps
+from flask import jsonify, request
+from flask_login import current_user
+
 # Import TensorFlow models
 
 
@@ -206,6 +210,28 @@ def _validate_image_magic(stream) -> bool:
         return True
     return False
 
+# Custom decorator to require login for API routes, returning JSON error if not authenticated
+def api_login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if current_user.is_authenticated:
+            return view(*args, **kwargs)
+
+        wants_json = (
+            request.is_json
+            or request.path.startswith("/api")
+            or request.headers.get("X-Requested-With") == "XMLHttpRequest"
+            or "application/json" in request.headers.get("Accept", "")
+        )
+
+        if wants_json:
+            return jsonify({"error": "Authentication required"}), 401
+
+        from flask import redirect, url_for
+
+        return redirect(url_for("auth.login", next=request.url))
+
+    return wrapped
 
 # Pre-warm model cache on first request to this blueprint
 @predict_disease_type_bp.before_request
@@ -217,7 +243,7 @@ def _warm_cache_on_first_request():
 #  Main prediction route
 @predict_disease_type_bp.route("/predict", methods=["POST"])
 @rate_limit("prediction")
-@login_required
+@api_login_required
 def predict():
     # Accept file as "image" or "file"
     if "image" not in request.files:
@@ -268,7 +294,7 @@ def predict():
     try:
         # NEW: Save the upload to a temp file on disk so Grad-CAM can read
         # it by path (PIL.open from a stream can only be read once).
-        suffix = os.path.splitext(image_file.filename or ".jpg")[1] or ".jpg"
+        suffix = ".jpg"
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             image_file.save(tmp)
             tmp_path = tmp.name
@@ -290,19 +316,14 @@ def predict():
 
             print(f"Prediction: {predicted_class}, " f"Confidence: {confidence:.4f}")
 
-            if confidence < CONFIDENCE_THRESHOLD:
-                return (
-                    jsonify(
-                        {
-                            "error": (
-                                f"The uploaded image does not appear to be a valid "
-                                f"{model_type} disease image. "
-                                "Please upload a clear medical image."
-                            ),
-                            "confidence": round(confidence * 100, 2),
-                        }
-                    ),
-                    400,
+            # Flag low-confidence predictions instead of treating them as invalid requests.
+            low_confidence = confidence < CONFIDENCE_THRESHOLD
+
+            warning_message = None
+            if low_confidence:
+                warning_message = (
+                    "Prediction confidence is low. "
+                    "Please upload a clearer medical image for a more reliable result."
                 )
 
             # 4. NEW: Generate Grad-CAM / Score-CAM heatmap
@@ -367,9 +388,11 @@ def predict():
                     "prediction": predicted_class,
                     "confidence": round(confidence * 100, 2),
                     "type": model_type,
-                    "gradcam_overlay": gradcam_overlay,  # NEW: base64 PNG, image + heatmap blended
-                    "gradcam_heatmap": gradcam_heatmap,  # NEW: base64 PNG, raw heatmap only
-                    "explanation_method": explanation_method,  # NEW: "grad-cam" | "score-cam" | None
+                    "low_confidence": low_confidence,
+                    "warning": warning_message,
+                    "gradcam_overlay": gradcam_overlay,
+                    "gradcam_heatmap": gradcam_heatmap,
+                    "explanation_method": explanation_method,
                 }
             ),
             200,

--- a/backend/templates/disease_detection_dashboard.html
+++ b/backend/templates/disease_detection_dashboard.html
@@ -98,6 +98,25 @@
                             <button type="button" class="btn-close" onclick="hideError()" aria-label="Close"></button>
                         </div>
 
+                        <div id="warning-container"
+                            class="alert alert-warning alert-dismissible fade show shadow-sm w-100 mb-3"
+                            role="alert"
+                            style="display:none;">
+
+                            <div class="d-flex align-items-center">
+                                <i class="fas fa-exclamation-triangle fs-5 me-2"></i>
+                                <div>
+                                    <strong class="me-1">Low Confidence:</strong>
+                                    <span id="warning-message"></span>
+                                </div>
+                            </div>
+
+                            <button type="button"
+                                    class="btn-close"
+                                    onclick="hideWarning()"
+                                    aria-label="Close"></button>
+                        </div>
+
                         <!-- Result Container -->
                         <div id="results-container" style="display: none;">
                           <div class="card bg-light mb-3 shadow-sm">
@@ -326,6 +345,15 @@
     document.getElementById("error-container").style.display = "none";
   }
 
+  function hideWarning() {
+    document.getElementById("warning-container").style.display = "none";
+  }
+
+  function showWarning(message) {
+    document.getElementById("warning-message").textContent = message;
+    document.getElementById("warning-container").style.display = "block";
+  }
+
   function showPredictionError(message) {
     document.getElementById("error-message").textContent = message;
     document.getElementById("error-container").style.display = "block";
@@ -338,9 +366,10 @@
       return;
     }
 
-    // Hide previous errors & results
+    // Hide previous errors, warnings & results
     hideError();
-    document.getElementById('results-container').style.display = 'none';
+    hideWarning();
+    document.getElementById("results-container").style.display = "none";
 
     // Show loading
     document.getElementById('loading').style.display = 'block';
@@ -364,20 +393,29 @@
       const data = await response.json();
 
       if (response.ok) {
-        // Insert the prediction results in the DOM
-        document.getElementById("ml-prediction-label").innerText = data.prediction;
-        document.getElementById("ml-probability").innerText = data.confidence + "%";
-        document.getElementById("results-container").style.display = "block";
+          document.getElementById("ml-prediction-label").innerText = data.prediction;
+          document.getElementById("ml-probability").innerText = data.confidence + "%";
+          document.getElementById("results-container").style.display = "block";
 
-        // Grad-CAM heatmap
-        if (data.gradcam_overlay && data.gradcam_heatmap) {
-          document.getElementById("gradcam-overlay").src = data.gradcam_overlay;
-          document.getElementById("gradcam-heatmap").src = data.gradcam_heatmap;
-          document.getElementById("explanation-method-badge").innerText = data.explanation_method || "";
-          document.getElementById("gradcam-container").style.display = "block";
-        } else {
-          document.getElementById("gradcam-container").style.display = "none";
-        }
+          // Show warning for low-confidence predictions
+          if (data.low_confidence) {
+              showWarning(
+                  data.warning ||
+                  "Prediction confidence is low. Please upload a clearer medical image."
+              );
+          }
+
+          // Grad-CAM heatmap
+          if (data.gradcam_overlay && data.gradcam_heatmap) {
+              document.getElementById("gradcam-overlay").src = data.gradcam_overlay;
+              document.getElementById("gradcam-heatmap").src = data.gradcam_heatmap;
+              document.getElementById("explanation-method-badge").innerText =
+                  data.explanation_method || "";
+              document.getElementById("gradcam-container").style.display = "block";
+          } else {
+              document.getElementById("gradcam-container").style.display = "none";
+          }
+        
       } else {
         showPredictionError(data.error || 'Prediction failed');
       }


### PR DESCRIPTION
## 📄 Description

This PR fixes issues in the image-based disease prediction workflow for both eye and skin disease detection.

This PR includes:

- [x] Fixes authentication redirect issue for image prediction requests
- [x] Fixes low-confidence image prediction handling
- [x] Updates the frontend to display low-confidence warnings instead of prediction failures

---

## 🔗 Related Issues

> Fixes #544

---

## ✨ Changes Summary

- Fixed the image prediction endpoint where authenticated `POST /predict` requests were being redirected (`302`) to `/login?next=/predict`, preventing eye disease predictions.
- Updated the backend to return successful responses (`200 OK`) for valid low-confidence skin disease predictions instead of `400 Bad Request`.
- Added `low_confidence` and `warning` fields to the API response for low-confidence predictions.
- Updated the frontend to display warning messages for low-confidence predictions while still showing prediction results.
- Preserved Grad-CAM / Score-CAM explainability visualizations for successful predictions.
- Improved the overall user experience of the image-based disease prediction workflow.

---

## 📸 Screenshots (if applicable)

### Eye Disease Prediction
- Successfully predicts eye diseases with confidence score.
- Displays Grad-CAM explainability visualization.

<img width="1918" height="936" alt="image" src="https://github.com/user-attachments/assets/7a1e76a1-bea3-43bc-8dfe-a4ca8cb737e1" />

### Skin Disease Prediction
- Successfully predicts skin diseases.
- Low-confidence predictions display a warning instead of showing a prediction failure.
- Score-CAM explainability visualization is displayed correctly.

<img width="1444" height="936" alt="image" src="https://github.com/user-attachments/assets/5b1a3c7f-0abb-42d0-b965-405e64beb015" />

---

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] I have commented code in hard-to-understand areas (where applicable)
- [x] My changes generate no new warnings