### PR TITLE
fix: reject weak SECRET_KEY in all environments, not just production

### DIFF
--- a/backend/routes/history_routes.py
+++ b/backend/routes/history_routes.py
@@ -236,7 +236,11 @@ def export_history_csv():
         if entry.results_json:
             try:
                 # Handle cases where results_json is already a dict, or parse it if it's a string
-                results_dict = json.loads(entry.results_json) if isinstance(entry.results_json, str) else entry.results_json
+                results_dict = (
+                    json.loads(entry.results_json)
+                    if isinstance(entry.results_json, str)
+                    else entry.results_json
+                )
                 bmi = results_dict.get("bmi", results_dict.get("BMI", ""))
             except Exception:
                 pass
@@ -244,12 +248,16 @@ def export_history_csv():
         # Fallback: compute from height/weight in inputs_json if not found in results
         if bmi == "" and entry.inputs_json:
             try:
-                inputs_dict = json.loads(entry.inputs_json) if isinstance(entry.inputs_json, str) else entry.inputs_json
+                inputs_dict = (
+                    json.loads(entry.inputs_json)
+                    if isinstance(entry.inputs_json, str)
+                    else entry.inputs_json
+                )
                 height_cm = inputs_dict.get("height_cm")
                 weight_kg = inputs_dict.get("weight_kg")
                 if height_cm and weight_kg:
                     height_m = float(height_cm) / 100
-                    bmi = round(float(weight_kg) / (height_m ** 2), 2)
+                    bmi = round(float(weight_kg) / (height_m**2), 2)
             except Exception:
                 pass
 

--- a/backend/routes/predict_disease_type_routes.py
+++ b/backend/routes/predict_disease_type_routes.py
@@ -210,6 +210,7 @@ def _validate_image_magic(stream) -> bool:
         return True
     return False
 
+
 # Custom decorator to require login for API routes, returning JSON error if not authenticated
 def api_login_required(view):
     @wraps(view)
@@ -232,6 +233,7 @@ def api_login_required(view):
         return redirect(url_for("auth.login", next=request.url))
 
     return wrapped
+
 
 # Pre-warm model cache on first request to this blueprint
 @predict_disease_type_bp.before_request

--- a/backend/tests/test_secret_key.py
+++ b/backend/tests/test_secret_key.py
@@ -89,23 +89,35 @@ def test_secret_key_with_flask_debug_flag(monkeypatch):
     assert len(app.config["SECRET_KEY"]) == 64
 
 
-def test_secret_key_length_validation(monkeypatch):
-    """Test that app requires a reasonably long SECRET_KEY"""
-    # Setup
+def test_secret_key_length_validation_rejected_in_production(monkeypatch):
+    """A short SECRET_KEY must be rejected in production."""
+    monkeypatch.setenv("SECRET_KEY", "short")  # Too short
+    monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "")
+
+    from backend import create_app
+
+    with pytest.raises(ValueError) as exc_info:
+        create_app()
+
+    assert "too weak" in str(exc_info.value)
+
+
+def test_secret_key_length_validation_rejected_in_development(monkeypatch):
+    """A weak, human-guessable SECRET_KEY is forgeable regardless of
+    environment label, so it must be rejected in development too instead
+    of being silently accepted (issue #594)."""
     monkeypatch.setenv("SECRET_KEY", "short")  # Too short
     monkeypatch.setenv("FLASK_ENV", "development")
     monkeypatch.setenv("DATABASE_URL", "")
 
-    # Import after setting env vars
     from backend import create_app
 
-    # Execute
-    app = create_app()
+    with pytest.raises(ValueError) as exc_info:
+        create_app()
 
-    # Assert - app should accept even short keys, but it's insecure
-    assert app.config["SECRET_KEY"] == "short"
-    # Note: A real implementation might validate minimum length, but this test
-    # documents current behavior
+    assert "too weak" in str(exc_info.value)
 
 
 def test_secret_key_not_hardcoded():

--- a/backend/utils/config_validator.py
+++ b/backend/utils/config_validator.py
@@ -20,17 +20,30 @@ def validate_startup_config(app):
 
     # 2. Check SECRET_KEY
     secret_key = os.getenv("SECRET_KEY")
-    if is_production:
-        if not secret_key:
-            raise ValueError(
-                "\n[ERROR] CRITICAL ERROR: SECRET_KEY environment variable is required in production!\n"
-                "   Please set SECRET_KEY in your .env file or environment settings.\n"
-            )
-        if len(secret_key) < 16:
-            raise ValueError(
-                f"\n[ERROR] CRITICAL ERROR: SECRET_KEY is too weak! Got length {len(secret_key)}, expected at least 16 characters.\n"
-                "   Please generate a strong random key for production.\n"
-            )
+    if is_production and not secret_key:
+        raise ValueError(
+            "\n[ERROR] CRITICAL ERROR: SECRET_KEY environment variable is required in production!\n"
+            "   Please set SECRET_KEY in your .env file or environment settings.\n"
+        )
+
+    # A weak, human-guessable SECRET_KEY is just as forgeable as a hardcoded
+    # default: session cookies signed with it can be forged by anyone who
+    # can brute-force or guess the short value. This check previously only
+    # ran when is_production was True, so a short SECRET_KEY set in a
+    # development or staging environment (a common misconfiguration) was
+    # silently accepted with no warning at all. Enforce it whenever a key
+    # was explicitly provided, regardless of environment; the auto-generated
+    # secrets.token_hex(32) fallback used when no key is set is always well
+    # above this threshold, so this never blocks the zero-config dev path.
+    if secret_key and len(secret_key) < 16:
+        message = (
+            f"SECRET_KEY is too weak! Got length {len(secret_key)}, expected at least 16 characters.\n"
+            "   Please generate a strong random key: "
+            'python -c "import secrets; print(secrets.token_hex(32))"\n'
+        )
+        if is_production:
+            raise ValueError(f"\n[ERROR] CRITICAL ERROR: {message}")
+        raise ValueError(f"\n[ERROR] CONFIGURATION ERROR: {message}")
 
     # 3. Check GEMINI_API_KEY
     gemini_key = os.getenv("GEMINI_API_KEY")

--- a/backend/utils/validators.py
+++ b/backend/utils/validators.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Load known disease names from hospital_data.csv at startup
 # ---------------------------------------------------------------------------
 
+
 def _load_known_diseases() -> list[str]:
     """Read disease names from hospital_data.csv. Returns empty list on failure."""
     csv_path = os.path.join(os.path.dirname(__file__), "..", "..", "hospital_data.csv")
@@ -32,7 +33,9 @@ def _load_known_diseases() -> list[str]:
                 if name and name.strip() not in diseases:
                     diseases.append(name.strip())
     except FileNotFoundError:
-        logger.warning("hospital_data.csv not found — disease name validation will be skipped.")
+        logger.warning(
+            "hospital_data.csv not found — disease name validation will be skipped."
+        )
     except Exception as exc:
         logger.warning("Could not load disease names for validation: %s", exc)
     return diseases
@@ -48,11 +51,17 @@ SUPPORTED_LANGUAGES: list[str] = ["en", "hi", "gu", "ta"]
 # Marshmallow Schemas
 # ---------------------------------------------------------------------------
 
+
 class BayesInputSchema(Schema):
     """Validates input for the Bayesian calculator endpoint."""
+
     disease = fields.Str(
         required=True,
-        validate=validate.OneOf(KNOWN_DISEASES) if KNOWN_DISEASES else validate.Length(min=1, max=100),
+        validate=(
+            validate.OneOf(KNOWN_DISEASES)
+            if KNOWN_DISEASES
+            else validate.Length(min=1, max=100)
+        ),
         error_messages={"required": "disease is required."},
     )
     prior = fields.Float(
@@ -83,6 +92,7 @@ class BayesInputSchema(Schema):
 
 class SymptomInputSchema(Schema):
     """Validates input for the ML symptom-based prediction endpoint."""
+
     symptoms = fields.List(
         fields.Str(validate=validate.Length(min=1, max=100)),
         required=True,
@@ -102,6 +112,7 @@ class SymptomInputSchema(Schema):
 
 class AILanguageSchema(Schema):
     """Validates the language parameter for AI recommendation routes."""
+
     language = fields.Str(
         load_default="en",
         validate=validate.OneOf(
@@ -134,6 +145,7 @@ def validate_input(schema_name: str):
             data = request.validated_data   # pre-validated dict
             ...
     """
+
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
@@ -151,11 +163,15 @@ def validate_input(schema_name: str):
             try:
                 validated = schema.load(raw)
             except ValidationError as err:
-                return jsonify({"error": "Validation failed.", "details": err.messages}), 400
+                return (
+                    jsonify({"error": "Validation failed.", "details": err.messages}),
+                    400,
+                )
 
             # Attach validated data to request for use in the view
             request.validated_data = validated
             return f(*args, **kwargs)
 
         return wrapper
+
     return decorator

--- a/dashboard.py
+++ b/dashboard.py
@@ -170,7 +170,10 @@ if app_mode == "Prediction":
         with col2:
             st.metric("Confidence Score", f"{result['confidence_score'] * 100:.1f}%")
         with col3:
-            st.metric("Symptoms Matched", f"{result['symptoms_matched']} / {result['total_symptoms']}")
+            st.metric(
+                "Symptoms Matched",
+                f"{result['symptoms_matched']} / {result['total_symptoms']}",
+            )
 
         st.write("### Risk Probability")
         st.progress(result["raw_probability"])
@@ -180,13 +183,17 @@ if app_mode == "Prediction":
         if prob < 30:
             st.success("✅ Low Risk: Symptoms do not strongly indicate this disease.")
         elif prob < 60:
-            st.warning("⚠️ Moderate Risk: Consider consulting a doctor for further evaluation.")
+            st.warning(
+                "⚠️ Moderate Risk: Consider consulting a doctor for further evaluation."
+            )
         else:
             st.error("🚨 High Risk: Immediate medical attention is recommended.")
 
         st.divider()
         st.subheader("Bayesian Probability Concept")
-        st.write("This prediction system uses probabilistic reasoning inspired by Bayes' Theorem to estimate disease likelihood based on symptoms.")
+        st.write(
+            "This prediction system uses probabilistic reasoning inspired by Bayes' Theorem to estimate disease likelihood based on symptoms."
+        )
         st.latex(r"P(D \mid S)=\frac{P(S \mid D)\cdot P(D)}{P(S)}")
         st.caption("D = Disease | S = Symptoms")
 

--- a/run.py
+++ b/run.py
@@ -13,6 +13,7 @@ load_dotenv()
 # Startup environment checks
 # ---------------------------------------------------------------------------
 
+
 def _check_environment():
     """Warn about missing optional keys and fail fast on required ones."""
     gemini_key = os.environ.get("GEMINI_API_KEY", "").strip()
@@ -37,4 +38,9 @@ if __name__ == "__main__":
     print("\n" + "=" * 50)
     print("  Disease Prediction — Flask Development Server")
     print("=" * 50 + "\n")
-    app.run(debug=True, host="0.0.0.0", port=5001, use_reloader=False)
+    # SECURITY: debug mode must never be hardcoded to True. create_app()
+    # already derives app.debug from FLASK_DEBUG/FLASK_ENV and forces it
+    # off in production; reuse that value instead of overriding it here,
+    # otherwise the Werkzeug debugger (arbitrary code execution) is always
+    # reachable regardless of environment configuration.
+    app.run(debug=app.debug, host="0.0.0.0", port=5001, use_reloader=False)


### PR DESCRIPTION
## Summary

Closes the remaining gap in `SECRET_KEY` validation: a short, human-guessable key was silently accepted whenever `FLASK_ENV` wasn't `production`.

## Problem

The application already rejects a missing `SECRET_KEY` in production and never hardcodes a default value, both of which properly address the session-forgery scenario this issue originally described. However, `validate_startup_config`'s 16-character minimum length check only ran when `is_production` was true. A short key such as `"short"` set in development or staging, a common real-world misconfiguration, was accepted with zero warning. `backend/tests/test_secret_key.py::test_secret_key_length_validation` explicitly documented this as current, accepted behavior.

A weak key is exactly as forgeable as a hardcoded default: an attacker who guesses or brute-forces it can sign valid session cookies and impersonate any user, regardless of what the environment happens to be labeled.

## Changes

- `config_validator.py`: the minimum-length check now runs whenever a `SECRET_KEY` was explicitly provided, independent of environment. It still raises with a production-specific message in production and a configuration-error message elsewhere. The auto-generated `secrets.token_hex(32)` fallback used when no key is set at all is always 64 characters, so the zero-config development path is unaffected.
- `test_secret_key.py`: replaced the test that documented weak-key-in-dev as acceptable with two tests asserting rejection, one for production and one for development.
- Also includes the same `black` formatting pass and the `run.py` hardcoded `debug=True` fix already applied in #606/#607, since CI's linting and CodeQL jobs run repo-wide regardless of PR diff scope.

## Testing

- `pytest backend/tests/ -v` — 171 passed
- `flake8 backend/ data/ run.py dashboard.py --select=E9,F63,F7,F82` — 0 issues
- `black --check backend/ data/ run.py dashboard.py` — clean
- Manually verified the Flask server still boots and responds under `FLASK_ENV=development` with a valid-length key

Fixes #594